### PR TITLE
Adjust AArch64 VSpace bindings for latest kernel

### DIFF
--- a/crates/private/support/sel4-simple-task/config-types/src/when_not_sel4.rs
+++ b/crates/private/support/sel4-simple-task/config-types/src/when_not_sel4.rs
@@ -21,9 +21,6 @@ dummies! {
     SmallPage
     LargePage
     HugePage
-    PGD
-    PUD
-    PD
     PT
     IRQControl
     IRQHandler

--- a/crates/sel4-capdl-initializer/types/src/when_sel4.rs
+++ b/crates/sel4-capdl-initializer/types/src/when_sel4.rs
@@ -35,10 +35,7 @@ impl<'a, D, M> Object<'a, D, M> {
                     let level = obj.level.unwrap();
                     assert_eq!(obj.is_root, level == 0); // sanity check
                     match level {
-                        0 => ObjectBlueprintSeL4Arch::PGD.into(),
-                        1 => ObjectBlueprintSeL4Arch::PUD.into(),
-                        2 => ObjectBlueprintArch::PD.into(),
-                        3 => ObjectBlueprintArch::PT.into(),
+                        0..3 => ObjectBlueprintSeL4Arch::PT.into(),
                         _ => panic!(),
                     }
                 }

--- a/crates/sel4/src/arch/arm/arch/aarch64/invocations.rs
+++ b/crates/sel4/src/arch/arm/arch/aarch64/invocations.rs
@@ -67,7 +67,7 @@ impl<T: FrameType, C: InvocationContext> LocalCPtr<T, C> {
     /// Corresponds to `seL4_ARM_Page_Map`.
     pub fn frame_map(
         self,
-        pgd: PGD,
+        pt: PT,
         vaddr: usize,
         rights: CapRights,
         attrs: VMAttributes,
@@ -75,7 +75,7 @@ impl<T: FrameType, C: InvocationContext> LocalCPtr<T, C> {
         Error::wrap(self.invoke(|cptr, ipc_buffer| {
             ipc_buffer.inner_mut().seL4_ARM_Page_Map(
                 cptr.bits(),
-                pgd.bits(),
+                pt.bits(),
                 vaddr.try_into().unwrap(),
                 rights.into_inner(),
                 attrs.into_inner(),
@@ -102,34 +102,8 @@ impl<T: FrameType, C: InvocationContext> LocalCPtr<T, C> {
     }
 }
 
-impl<C: InvocationContext> PUD<C> {
-    pub fn pud_map(self, vspace: PGD, vaddr: usize, attr: VMAttributes) -> Result<()> {
-        Error::wrap(self.invoke(|cptr, ipc_buffer| {
-            ipc_buffer.inner_mut().seL4_ARM_PageUpperDirectory_Map(
-                cptr.bits(),
-                vspace.bits(),
-                vaddr.try_into().unwrap(),
-                attr.into_inner(),
-            )
-        }))
-    }
-}
-
-impl<C: InvocationContext> PD<C> {
-    pub fn pd_map(self, vspace: PGD, vaddr: usize, attr: VMAttributes) -> Result<()> {
-        Error::wrap(self.invoke(|cptr, ipc_buffer| {
-            ipc_buffer.inner_mut().seL4_ARM_PageDirectory_Map(
-                cptr.bits(),
-                vspace.bits(),
-                vaddr.try_into().unwrap(),
-                attr.into_inner(),
-            )
-        }))
-    }
-}
-
 impl<C: InvocationContext> PT<C> {
-    pub fn pt_map(self, vspace: PGD, vaddr: usize, attr: VMAttributes) -> Result<()> {
+    pub fn pt_map(self, vspace: PT, vaddr: usize, attr: VMAttributes) -> Result<()> {
         Error::wrap(self.invoke(|cptr, ipc_buffer| {
             ipc_buffer.inner_mut().seL4_ARM_PageTable_Map(
                 cptr.bits(),
@@ -202,11 +176,11 @@ impl<C: InvocationContext> ASIDControl<C> {
 
 impl<C: InvocationContext> ASIDPool<C> {
     /// Corresponds to `seL4_ARM_ASIDPool_Assign`.
-    pub fn asid_pool_assign(self, pd: PGD) -> Result<()> {
+    pub fn asid_pool_assign(self, pt: PT) -> Result<()> {
         Error::wrap(self.invoke(|cptr, ipc_buffer| {
             ipc_buffer
                 .inner_mut()
-                .seL4_ARM_ASIDPool_Assign(cptr.bits(), pd.bits())
+                .seL4_ARM_ASIDPool_Assign(cptr.bits(), pt.bits())
         }))
     }
 }

--- a/crates/sel4/src/arch/arm/arch/aarch64/object.rs
+++ b/crates/sel4/src/arch/arm/arch/aarch64/object.rs
@@ -12,16 +12,12 @@ pub type ObjectBlueprintSeL4Arch = ObjectBlueprintAArch64;
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ObjectTypeAArch64 {
     HugePage,
-    PUD,
-    PGD,
 }
 
 impl ObjectTypeAArch64 {
     pub(crate) const fn into_sys(self) -> c_uint {
         match self {
             Self::HugePage => sys::_mode_object::seL4_ARM_HugePageObject,
-            Self::PUD => sys::_mode_object::seL4_ARM_PageUpperDirectoryObject,
-            Self::PGD => sys::_mode_object::seL4_ARM_PageGlobalDirectoryObject,
         }
     }
 }
@@ -30,24 +26,18 @@ impl ObjectTypeAArch64 {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ObjectBlueprintAArch64 {
     HugePage,
-    PUD,
-    PGD,
 }
 
 impl ObjectBlueprintAArch64 {
     pub(crate) const fn ty(self) -> ObjectTypeAArch64 {
         match self {
             Self::HugePage => ObjectTypeAArch64::HugePage,
-            Self::PUD => ObjectTypeAArch64::PUD,
-            Self::PGD => ObjectTypeAArch64::PGD,
         }
     }
 
     pub(crate) const fn physical_size_bits(self) -> usize {
         match self {
             Self::HugePage => u32_into_usize(sys::seL4_HugePageBits),
-            Self::PUD => u32_into_usize(sys::seL4_PUDBits),
-            Self::PGD => u32_into_usize(sys::seL4_PGDBits),
         }
     }
 }

--- a/crates/sel4/src/arch/arm/arch/aarch64/vspace.rs
+++ b/crates/sel4/src/arch/arm/arch/aarch64/vspace.rs
@@ -41,14 +41,6 @@ impl FrameType for cap_type::HugePage {
 
 //
 
-impl cap_type::PUD {
-    pub const SPAN_BITS: usize = cap_type::PD::SPAN_BITS + (sys::seL4_PUDIndexBits as usize);
-}
-
-impl cap_type::PD {
-    pub const SPAN_BITS: usize = cap_type::PT::SPAN_BITS + (sys::seL4_PageDirIndexBits as usize);
-}
-
 impl cap_type::PT {
     pub const SPAN_BITS: usize = FrameSize::Small.bits() + (sys::seL4_PageTableIndexBits as usize);
 }

--- a/crates/sel4/src/arch/arm/mod.rs
+++ b/crates/sel4/src/arch/arm/mod.rs
@@ -43,27 +43,12 @@ pub(crate) mod cap_type_arch {
     }
 
     declare_cap_type! {
-        /// Corresponds to `seL4_ARM_VSpace`.
-        PGD
-    }
-
-    declare_cap_type! {
-        /// Corresponds to `seL4_ARM_PageUpperDirectory`.
-        PUD
-    }
-
-    declare_cap_type! {
-        /// Corresponds to `seL4_ARM_PageDirectory`.
-        PD
-    }
-
-    declare_cap_type! {
         /// Corresponds to `seL4_ARM_PageTable`.
         PT
     }
 
-    /// Alias for [`cap_type::PGD`](PGD).
-    pub type VSpace = PGD;
+    /// Alias for [`cap_type::PT`](PT).
+    pub type VSpace = PT;
 
     /// Alias for [`cap_type::SmallPage`](SmallPage).
     pub type Granule = SmallPage;
@@ -78,8 +63,5 @@ pub(crate) mod local_cptr_arch {
     declare_local_cptr_alias!(SmallPage);
     declare_local_cptr_alias!(LargePage);
     declare_local_cptr_alias!(HugePage);
-    declare_local_cptr_alias!(PGD);
-    declare_local_cptr_alias!(PUD);
-    declare_local_cptr_alias!(PD);
     declare_local_cptr_alias!(PT);
 }

--- a/crates/sel4/src/arch/arm/object.rs
+++ b/crates/sel4/src/arch/arm/object.rs
@@ -20,7 +20,6 @@ pub enum ObjectTypeArm {
     SmallPage,
     LargePage,
     PT,
-    PD,
     #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
     VCPU,
     SeL4Arch(ObjectTypeSeL4Arch),
@@ -33,7 +32,6 @@ impl ObjectTypeArm {
             Self::SmallPage => sys::_object::seL4_ARM_SmallPageObject,
             Self::LargePage => sys::_object::seL4_ARM_LargePageObject,
             Self::PT => sys::_object::seL4_ARM_PageTableObject,
-            Self::PD => sys::_object::seL4_ARM_PageDirectoryObject,
             #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
             Self::VCPU => sys::_object::seL4_ARM_VCPUObject,
             Self::SeL4Arch(sel4_arch) => sel4_arch.into_sys(),
@@ -60,7 +58,6 @@ pub enum ObjectBlueprintArm {
     SmallPage,
     LargePage,
     PT,
-    PD,
     #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
     VCPU,
     SeL4Arch(ObjectBlueprintSeL4Arch),
@@ -73,7 +70,6 @@ impl ObjectBlueprintArm {
             Self::SmallPage => ObjectTypeArm::SmallPage,
             Self::LargePage => ObjectTypeArm::LargePage,
             Self::PT => ObjectTypeArm::PT,
-            Self::PD => ObjectTypeArm::PD,
             #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
             Self::VCPU => ObjectTypeArm::VCPU,
             Self::SeL4Arch(sel4_arch) => ObjectTypeArch::SeL4Arch(sel4_arch.ty()),
@@ -86,7 +82,6 @@ impl ObjectBlueprintArm {
             Self::SmallPage => u32_into_usize(sys::seL4_PageBits),
             Self::LargePage => u32_into_usize(sys::seL4_LargePageBits),
             Self::PT => u32_into_usize(sys::seL4_PageTableBits),
-            Self::PD => u32_into_usize(sys::seL4_PageDirBits),
             #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
             Self::VCPU => u32_into_usize(sys::seL4_VCPUBits),
             Self::SeL4Arch(sel4_arch) => sel4_arch.physical_size_bits(),


### PR DESCRIPTION
seL4_ARM_PageUpperDirectory and seL4_ARM_PageDirectory have been removed, with seL4_ARM_PageTable being used for all levels of AArch64 page tables.

I believe all mentions of PGD, PUD, and PD are gone now. The only problem is that the CapDL initializer changes are *not* tested.