### PR TITLE
github: add foundation templates

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,12 @@
+<!--
+     Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Code of Conduct
+
+This repository and interactions with it fall under the [seL4 Code of Conduct][1] available from the [seL4 website][2].
+
+[1]: https://docs.sel4.systems/processes/conduct.html
+[2]: https://sel4.systems

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+<!--
+     Copyright 2020, Data61, CSIRO (ABN 41 687 119 230)
+
+     SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Contributions Welcome
+
+Please see the [seL4 contributing guidelines][1] on the [seL4 website][2] for
+details.
+
+[1]: https://docs.sel4.systems/processes/contributing.html
+[2]: https://sel4.systems
+
+
+## Contact
+
+If you have larger changes or additions, it is a good idea to get in contact
+with us as <devel@sel4.systems>, so we can help you get started.
+
+The people responsible for the technical direction, procedures, and quality
+control are the [Technical Steering Committee][3] (TSC) of the seL4
+foundation. You can contact them either on the developer mailing list or on
+directly via email available from their profile pages.
+
+[3]: https://sel4.systems/Foundation/TSC
+
+
+## Developer Certificate of Origin (DCO)
+
+This repository uses the same sign-off process as the Linux kernel. For every
+commit, use
+
+    git commit -s
+
+to add a sign-off line to your commit message, which will come out as:
+
+    Signed-off-by: name <email>
+
+By adding this line, you make the declaration that you have the right to make
+this contribution under the open source license the files use that you changed
+or contributed.
+
+The full text of the declaration is at <https://developercertificate.org>.


### PR DESCRIPTION
Standard templates for foundation repos for code of conduct and contribution guidelines. The latter can be extended if needed.

Both will show up in the GitHub UI for new pull requests etc.