### PR TITLE
Remove dependence on setvar patch for Microkit

### DIFF
--- a/crates/examples/microkit/http-server/http-server.system
+++ b/crates/examples/microkit/http-server/http-server.system
@@ -27,7 +27,6 @@
         <program_image path="microkit-http-server-example-server.elf" />
 
         <map mr="virtio_net_client_dma" vaddr="0x1_000_000_000" perms="rw" cached="true" setvar_vaddr="virtio_net_client_dma_vaddr" />
-        <setvar symbol="virtio_net_client_dma_size" vaddr="0x200_000" />
 
         <map mr="virtio_net_rx_free" vaddr="0x2_000_000_000" perms="rw" cached="true" setvar_vaddr="virtio_net_rx_free" />
         <map mr="virtio_net_rx_used" vaddr="0x2_001_000_000" perms="rw" cached="true" setvar_vaddr="virtio_net_rx_used" />
@@ -35,7 +34,6 @@
         <map mr="virtio_net_tx_used" vaddr="0x2_003_000_000" perms="rw" cached="true" setvar_vaddr="virtio_net_tx_used" />
 
         <map mr="virtio_blk_client_dma" vaddr="0x3_000_000_000" perms="rw" cached="true" setvar_vaddr="virtio_blk_client_dma_vaddr" />
-        <setvar symbol="virtio_blk_client_dma_size" vaddr="0x200_000" />
 
         <map mr="virtio_blk_free" vaddr="0x4_000_000_000" perms="rw" cached="true" setvar_vaddr="virtio_blk_free" />
         <map mr="virtio_blk_used" vaddr="0x4_001_000_000" perms="rw" cached="true" setvar_vaddr="virtio_blk_used" />
@@ -45,21 +43,17 @@
         <program_image path="microkit-http-server-example-sp804-driver.elf" />
         <map mr="sp804_mmio"  vaddr="0x5_000_000_000" perms="rw" cached="false" setvar_vaddr="sp804_mmio_vaddr" />
         <irq irq="43" id="0" />
-        <setvar symbol="freq" vaddr="1_000_000" />
     </protection_domain>
 
     <protection_domain name="virtio_net_driver" pp="true" priority="253">
         <program_image path="microkit-http-server-example-virtio-net-driver.elf" />
 
         <map mr="virtio_mmio" vaddr="0x6_000_000_000" perms="rw" cached="false" setvar_vaddr="virtio_net_mmio_vaddr" />
-        <setvar symbol="virtio_net_mmio_offset" vaddr="0xe00" />
 
         <map mr="virtio_net_driver_dma" vaddr="0x7_000_000_000" perms="rw" cached="true" setvar_vaddr="virtio_net_driver_dma_vaddr" />
-        <setvar symbol="virtio_net_driver_dma_size" vaddr="0x200_000" />
         <setvar symbol="virtio_net_driver_dma_paddr" region_paddr="virtio_net_driver_dma" />
 
         <map mr="virtio_net_client_dma" vaddr="0x1_000_000_000" perms="rw" cached="true" setvar_vaddr="virtio_net_client_dma_vaddr" />
-        <setvar symbol="virtio_net_client_dma_size" vaddr="0x200_000" />
 
         <map mr="virtio_net_rx_free" vaddr="0x2_000_000_000" perms="rw" cached="true" setvar_vaddr="virtio_net_rx_free" />
         <map mr="virtio_net_rx_used" vaddr="0x2_001_000_000" perms="rw" cached="true" setvar_vaddr="virtio_net_rx_used" />
@@ -73,14 +67,11 @@
         <program_image path="microkit-http-server-example-virtio-blk-driver.elf" />
 
         <map mr="virtio_mmio" vaddr="0x6_000_000_000" perms="rw" cached="false" setvar_vaddr="virtio_blk_mmio_vaddr" />
-        <setvar symbol="virtio_blk_mmio_offset" vaddr="0xc00" />
 
         <map mr="virtio_blk_driver_dma" vaddr="0x8_000_000_000" perms="rw" cached="true" setvar_vaddr="virtio_blk_driver_dma_vaddr" />
-        <setvar symbol="virtio_blk_driver_dma_size" vaddr="0x200_000" />
         <setvar symbol="virtio_blk_driver_dma_paddr" region_paddr="virtio_blk_driver_dma" />
 
         <map mr="virtio_blk_client_dma" vaddr="0x3_000_000_000" perms="rw" cached="true" setvar_vaddr="virtio_blk_client_dma_vaddr" />
-        <setvar symbol="virtio_blk_client_dma_size" vaddr="0x200_000" />
 
         <map mr="virtio_blk_free" vaddr="0x4_000_000_000" perms="rw" cached="true" setvar_vaddr="virtio_blk_free" />
         <map mr="virtio_blk_used" vaddr="0x4_001_000_000" perms="rw" cached="true" setvar_vaddr="virtio_blk_used" />

--- a/crates/examples/microkit/http-server/pds/server/src/config.rs
+++ b/crates/examples/microkit/http-server/pds/server/src/config.rs
@@ -1,0 +1,16 @@
+//
+// Copyright 2023, Colias Group, LLC
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+
+pub mod channels {
+    use sel4_microkit::Channel;
+
+    pub const TIMER_DRIVER: Channel = Channel::new(0);
+    pub const NET_DRIVER: Channel = Channel::new(1);
+    pub const BLOCK_DRIVER: Channel = Channel::new(2);
+}
+
+pub const VIRTIO_NET_CLIENT_DMA_SIZE: usize = 0x200_000;
+pub const VIRTIO_BLK_CLIENT_DMA_SIZE: usize = 0x200_000;

--- a/crates/examples/microkit/http-server/pds/sp804-driver/src/config.rs
+++ b/crates/examples/microkit/http-server/pds/sp804-driver/src/config.rs
@@ -1,0 +1,14 @@
+//
+// Copyright 2023, Colias Group, LLC
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+
+pub mod channels {
+    use sel4_microkit::Channel;
+
+    pub const DEVICE: Channel = Channel::new(0);
+    pub const CLIENT: Channel = Channel::new(1);
+}
+
+pub const FREQ: u64 = 1_000_000;

--- a/crates/examples/microkit/http-server/pds/virtio-blk-driver/src/config.rs
+++ b/crates/examples/microkit/http-server/pds/virtio-blk-driver/src/config.rs
@@ -1,0 +1,16 @@
+//
+// Copyright 2023, Colias Group, LLC
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+
+pub mod channels {
+    use sel4_microkit::Channel;
+
+    pub const DEVICE: Channel = Channel::new(0);
+    pub const CLIENT: Channel = Channel::new(1);
+}
+
+pub const VIRTIO_BLK_MMIO_OFFSET: usize = 0xc00;
+pub const VIRTIO_BLK_DRIVER_DMA_SIZE: usize = 0x200_000;
+pub const VIRTIO_BLK_CLIENT_DMA_SIZE: usize = 0x200_000;

--- a/crates/examples/microkit/http-server/pds/virtio-net-driver/src/config.rs
+++ b/crates/examples/microkit/http-server/pds/virtio-net-driver/src/config.rs
@@ -1,0 +1,16 @@
+//
+// Copyright 2023, Colias Group, LLC
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+
+pub mod channels {
+    use sel4_microkit::Channel;
+
+    pub const DEVICE: Channel = Channel::new(0);
+    pub const CLIENT: Channel = Channel::new(1);
+}
+
+pub const VIRTIO_NET_MMIO_OFFSET: usize = 0xe00;
+pub const VIRTIO_NET_DRIVER_DMA_SIZE: usize = 0x200_000;
+pub const VIRTIO_NET_CLIENT_DMA_SIZE: usize = 0x200_000;

--- a/hacking/nix/scope/sources.nix
+++ b/hacking/nix/scope/sources.nix
@@ -65,7 +65,7 @@ in rec {
 
   microkit = fetchGit {
     url = "https://github.com/coliasgroup/microkit.git";
-    rev = "3dbabd1205cbee933b1ef42534d7a446f78821d0"; # branch "rust-nix"
+    rev = "1e561e5b11970a3b61167225ebcaf11aa7ad4959"; # branch "rust-nix"
     local = localRoot + "/microkit";
     # useLocal = true;
   };


### PR DESCRIPTION
Drop the [`setvar` patch](https://github.com/coliasgroup/microkit/commit/acab5b66cb8d66754deb18736fc82a4b) that will not be upstreamed.
