### PR TITLE
Update zerocopy due to vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.6",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -1929,7 +1929,7 @@ dependencies = [
  "log",
  "lru",
  "sel4-async-block-io",
- "zerocopy 0.7.6",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -2266,7 +2266,7 @@ name = "sel4-externally-shared"
 version = "0.1.0"
 dependencies = [
  "volatile",
- "zerocopy 0.7.6",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -2421,7 +2421,7 @@ dependencies = [
  "num_enum",
  "postcard",
  "serde",
- "zerocopy 0.7.6",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -2523,7 +2523,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "sel4-externally-shared",
- "zerocopy 0.7.6",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -2547,7 +2547,7 @@ version = "0.1.0"
 dependencies = [
  "num_enum",
  "sel4-shared-ring-buffer",
- "zerocopy 0.7.6",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -2623,7 +2623,7 @@ name = "sel4-simple-task-runtime-config-types"
 version = "0.1.0"
 dependencies = [
  "serde",
- "zerocopy 0.7.6",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -3417,12 +3417,12 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.6"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acf0fc2746d3e32f07be6067e170628e3b3d558c68f5dbada298039a6726331"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "byteorder",
- "zerocopy-derive 0.7.6",
+ "zerocopy-derive 0.7.32",
 ]
 
 [[package]]
@@ -3438,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.6"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b539ef18157ab9e248758ab68041c0179e639024ca17c794c6afa7a691f4c271"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/private/support/sel4-simple-task/runtime/config/types/Cargo.toml
+++ b/crates/private/support/sel4-simple-task/runtime/config/types/Cargo.toml
@@ -22,4 +22,4 @@ serde = ["dep:serde"]
 
 [dependencies]
 serde = { version = "1.0.147", default-features = false, features = ["derive"], optional = true }
-zerocopy = { version = "0.7.6", features = ["derive"] }
+zerocopy = { version = "0.7.32", features = ["derive"] }

--- a/crates/sel4-async/block-io/cpiofs/Cargo.toml
+++ b/crates/sel4-async/block-io/cpiofs/Cargo.toml
@@ -22,4 +22,4 @@ hex = { version = "0.4.3", default-features = false }
 log = "0.4.17"
 lru = "0.10.0"
 sel4-async-block-io = { path = ".." }
-zerocopy = { version = "0.7.6", features = ["derive"] }
+zerocopy = { version = "0.7.32", features = ["derive"] }

--- a/crates/sel4-externally-shared/Cargo.toml
+++ b/crates/sel4-externally-shared/Cargo.toml
@@ -21,7 +21,7 @@ unstable = ["volatile/unstable"]
 very_unstable = ["volatile/very_unstable"]
 
 [dependencies]
-zerocopy = "0.7.6"
+zerocopy = "0.7.32"
 
 [dependencies.volatile]
 git = "https://github.com/coliasgroup/volatile.git"

--- a/crates/sel4-microkit/message/types/Cargo.toml
+++ b/crates/sel4-microkit/message/types/Cargo.toml
@@ -24,4 +24,4 @@ postcard = ["dep:postcard", "dep:serde"]
 num_enum = { version = "0.5.9", default-features = false }
 postcard = { version = "1.0.2", default-features = false, optional = true }
 serde = { version = "1.0.147", default-features = false, optional = true }
-zerocopy = "0.7.6"
+zerocopy = "0.7.32"

--- a/crates/sel4-shared-ring-buffer/Cargo.toml
+++ b/crates/sel4-shared-ring-buffer/Cargo.toml
@@ -19,4 +19,4 @@ license = "BSD-2-Clause"
 [dependencies]
 log = "0.4.17"
 sel4-externally-shared = { path = "../sel4-externally-shared", features = ["unstable"] }
-zerocopy = { version = "0.7.6", features = ["derive"] }
+zerocopy = { version = "0.7.32", features = ["derive"] }

--- a/crates/sel4-shared-ring-buffer/block-io/types/Cargo.toml
+++ b/crates/sel4-shared-ring-buffer/block-io/types/Cargo.toml
@@ -19,4 +19,4 @@ license = "BSD-2-Clause"
 [dependencies]
 num_enum = { version = "0.5.9", default-features = false }
 sel4-shared-ring-buffer = { path = "../.." }
-zerocopy = { version = "0.7.6", features = ["derive"] }
+zerocopy = { version = "0.7.32", features = ["derive"] }

--- a/hacking/cargo-manifest-management/manifest-scope.nix
+++ b/hacking/cargo-manifest-management/manifest-scope.nix
@@ -98,7 +98,7 @@ in rec {
     tock-registers = "0.8.1";
     unwinding = "0.1.6";
     virtio-drivers = "0.5.0";
-    zerocopy = "0.7.6";
+    zerocopy = "0.7.32";
   };
 
   zerocopyWith = features: filterOutEmptyFeatureList {


### PR DESCRIPTION
This branch updates the `zerocopy` dependency to 0.7.32, due a vulnerability in 0.7.6 that was causing `make check-dependencies` to fail. The `cargo-audit` error was the following:
```
Crate:     zerocopy
Version:   0.7.6
Title:     Some Ref methods are unsound with some type parameters
Date:      2023-12-14
ID:        RUSTSEC-2023-0074
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0074
Solution:  Upgrade to >=0.2.9, <0.3.0 OR >=0.3.2, <0.4.0 OR >=0.4.1, <0.5.0 OR >=0.5.2, <0.6.0 OR >=0.6.6, <0.7.0 OR >=0.7.31
```