### PR TITLE
cmm: Fix handling of top-level arrays of tables

### DIFF
--- a/hacking/cargo-manifest-management/Makefile
+++ b/hacking/cargo-manifest-management/Makefile
@@ -13,7 +13,7 @@ none:
 
 .PHONY: clean
 clean:
-	rm -rf $(target_dir) $(blueprint)
+	rm -rf tool/target $(blueprint)
 
 .PHONY: $(blueprint)
 $(blueprint):

--- a/hacking/cargo-manifest-management/manual-manifests.nix
+++ b/hacking/cargo-manifest-management/manual-manifests.nix
@@ -8,11 +8,9 @@ let
 
   relativeToWorkspaceRoot = relativePath: "${toString ../..}/${relativePath}";
 
+  relativeToTmpSrc = relativePath: relativeToWorkspaceRoot "tmp/src/${relativePath}";
+
 in {
-  # "virtio-drivers" = relativeToWorkspaceRoot "tmp/virtio-drivers";
-  # "mbedtls" = relativeToWorkspaceRoot "tmp/rust-mbedtls/mbedtls";
-  # "mbedtls-sys-auto" = relativeToWorkspaceRoot "tmp/rust-mbedtls/mbedtls-sys";
-  # "mbedtls-platform-support" = relativeToWorkspaceRoot "tmp/rust-mbedtls/mbedtls-platform-support";
-  # "embedded-fat" = relativeToWorkspaceRoot "tmp/rust-embedded-fat";
-  # "volatile" = relativeToWorkspaceRoot "tmp/volatile";
+  # ring = relativeToTmpSrc "ring";
+  # rustls = relativeToTmpSrc "rustls/rustls";
 }

--- a/hacking/cargo-manifest-management/tool/crates/manage-cargo-manifests/src/main.rs
+++ b/hacking/cargo-manifest-management/tool/crates/manage-cargo-manifests/src/main.rs
@@ -40,6 +40,7 @@ pub struct Blueprint {
     pub entries: Vec<Entry>,
 }
 
+// TODO these rename attributes cause a mix of caml and snake case
 #[derive(Debug, Deserialize)]
 pub struct Entry {
     #[serde(rename = "absolutePath")]


### PR DESCRIPTION
Manifests with things like `[[bin]]` did not work before.