### PR TITLE
nix: Add `riscv*gc` targets

### DIFF
--- a/hacking/nix/overlay/default.nix
+++ b/hacking/nix/overlay/default.nix
@@ -35,9 +35,4 @@ assert !(super ? scopeName);
     (callPackage ./python-overrides.nix {})
   ];
 
-  # HACK: something wrong with multilib for riscv beyond gcc11 in nixpkgs
-  gccMultiStdenvGeneric = overrideCC stdenv (buildPackages.wrapCC (gcc11Stdenv.cc.cc.override {
-    enableMultilib = true;
-  }));
-
 }

--- a/hacking/nix/scope/default.nix
+++ b/hacking/nix/scope/default.nix
@@ -76,8 +76,8 @@ superCallPackage ../rust-utils {} self //
   rustTargetArchName = {
     aarch64 = "aarch64";
     aarch32 = "armv7a";
-    riscv64 = "riscv64imac";
-    riscv32 = "riscv32imac";
+    riscv64 = "riscv64${hostPlatform.this.rustTargetRiscVArch}";
+    riscv32 = "riscv32${hostPlatform.this.rustTargetRiscVArch}";
     x86_64 = "x86_64";
     ia32 = "i686";
   }."${seL4Arch}";
@@ -92,8 +92,8 @@ superCallPackage ../rust-utils {} self //
   bareMetalRustTargetInfo = mkBuiltinRustTargetInfo {
     aarch64 = "aarch64-unknown-none";
     aarch32 = "armv7a-none-eabi"; # armv7a-none-eabihf?
-    riscv64 = "riscv64imac-unknown-none-elf"; # gc?
-    riscv32 = "riscv32imac-unknown-none-elf"; # gc?
+    riscv64 = "riscv64${hostPlatform.this.rustTargetRiscVArch}-unknown-none-elf";
+    riscv32 = "riscv32${hostPlatform.this.rustTargetRiscVArch}-unknown-none-elf";
     x86_64 = "x86_64-unknown-none";
     ia32 = "i686-unknown-linux-gnu"; # HACK
   }."${seL4Arch}";

--- a/hacking/nix/scope/default.nix
+++ b/hacking/nix/scope/default.nix
@@ -60,20 +60,14 @@ superCallPackage ../rust-utils {} self //
 
   sources = callPackage ./sources.nix {};
 
-  seL4Arch =
-    lib.head
-      (map
-        (x: lib.elemAt x 1)
-        (lib.filter
-          (x: lib.elemAt x 0)
-          (with hostPlatform; [
-            [ isAarch64 "aarch64" ]
-            [ isAarch32 "aarch32" ]
-            [ isRiscV64 "riscv64" ]
-            [ isRiscV32 "riscv32" ]
-            [ isx86_64 "x86_64" ]
-            [ isx86_32 "ia32" ]
-          ])));
+  seL4Arch = with hostPlatform;
+    if isAarch64 then "aarch64" else
+    if isAarch32 then "aarch32" else
+    if isRiscV64 then "riscv64" else
+    if isRiscV32 then "riscv32" else
+    if isx86_64 then "x86_64" else
+    if isx86_32 then "ia32" else
+    throw "unkown platform";
 
   ### rust
 

--- a/hacking/nix/scope/sel4/default.nix
+++ b/hacking/nix/scope/sel4/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation {
     dtc libxml2
     python3Packages.sel4-deps
   ];
+
   depsBuildBuild = [
     # NOTE: cause drv.__spliced.buildBuild to be used to work around splicing issue
     qemuForSeL4

--- a/hacking/nix/scope/sources.nix
+++ b/hacking/nix/scope/sources.nix
@@ -35,7 +35,8 @@ let
   srcRoot = ../../..;
 
   # TODO
-  localRoot = srcRoot + "/tmp/src";
+  # localRoot = srcRoot + "/tmp/src";
+  localRoot = srcRoot + "/../x";
 
   mkKeepRef = rev: "refs/tags/keep/${builtins.substring 0 32 rev}";
 
@@ -60,7 +61,7 @@ in rec {
 
     rust-sel4test = fetchGit {
       url = "https://github.com/coliasgroup/seL4.git";
-      rev = "b31b459876e01008336394bfa90388d8729ff5f5"; # rust-sel4test
+      rev = "85e36760bd158cf12a170450685eb7b0b05d2076"; # rust-sel4test
       local = localRoot + "/seL4";
     };
   };

--- a/hacking/nix/scope/world/default.nix
+++ b/hacking/nix/scope/world/default.nix
@@ -130,7 +130,7 @@ self: with self;
     inherit (worldConfig) kernelLoaderConfig;
   };
 
-  mkSeL4KernelWithPayload = { appELF } : callPackage ./mk-sel4-kernel-loader-with-payload.nix {} {
+  mkSeL4KernelLoaderWithPayload = { appELF } : callPackage ./mk-sel4-kernel-loader-with-payload.nix {} {
     app = appELF;
   };
 

--- a/hacking/nix/scope/world/instances/default.nix
+++ b/hacking/nix/scope/world/instances/default.nix
@@ -77,7 +77,7 @@ in rec {
           rootCrate = crates.tests-root-task-loader;
           release = false;
         };
-        extraPlatformArgs = lib.optionalAttrs canSimulate  {
+        extraPlatformArgs = lib.optionalAttrs canSimulate {
           canAutomateSimply = true;
         };
       });
@@ -87,7 +87,7 @@ in rec {
           rootCrate = crates.tests-root-task-core-libs;
           release = false;
         };
-        extraPlatformArgs = lib.optionalAttrs canSimulate  {
+        extraPlatformArgs = lib.optionalAttrs canSimulate {
           canAutomateSimply = true;
         };
       });
@@ -97,7 +97,7 @@ in rec {
           rootCrate = crates.tests-root-task-config;
           release = false;
         };
-        extraPlatformArgs = lib.optionalAttrs canSimulate  {
+        extraPlatformArgs = lib.optionalAttrs canSimulate {
           canAutomateSimply = true;
         };
       });
@@ -107,7 +107,7 @@ in rec {
           rootCrate = crates.tests-root-task-tls;
           release = false;
         };
-        extraPlatformArgs = lib.optionalAttrs canSimulate  {
+        extraPlatformArgs = lib.optionalAttrs canSimulate {
           canAutomateSimply = true;
         };
       });
@@ -126,7 +126,7 @@ in rec {
             elf = embedDebugInfo orig.elf;
             inherit orig;
           };
-        extraPlatformArgs = lib.optionalAttrs canSimulate  {
+        extraPlatformArgs = lib.optionalAttrs canSimulate {
           canAutomateSimply = true;
         };
         extraLinks = [
@@ -157,7 +157,7 @@ in rec {
                       panic = panicStrategyName;
                     };
                   };
-                  extraPlatformArgs = lib.optionalAttrs canSimulate  {
+                  extraPlatformArgs = lib.optionalAttrs canSimulate {
                     canAutomateSimply = panicStrategyName == "unwind";
                   };
                 })));
@@ -181,7 +181,7 @@ in rec {
             });
           };
         };
-        extraPlatformArgs = lib.optionalAttrs canSimulate  {
+        extraPlatformArgs = lib.optionalAttrs canSimulate {
           canAutomateSimply = true;
         };
       });
@@ -207,7 +207,7 @@ in rec {
             };
           };
         };
-        extraPlatformArgs = lib.optionalAttrs canSimulate  {
+        extraPlatformArgs = lib.optionalAttrs canSimulate {
           canAutomateSimply = true;
         };
       });
@@ -228,7 +228,7 @@ in rec {
             };
           };
         };
-        extraPlatformArgs = lib.optionalAttrs canSimulate  {
+        extraPlatformArgs = lib.optionalAttrs canSimulate {
           canAutomateSimply = true;
         };
       });
@@ -256,7 +256,7 @@ in rec {
           rootCrate = crates.example-root-task;
           release = false;
         };
-        extraPlatformArgs = lib.optionalAttrs canSimulate  {
+        extraPlatformArgs = lib.optionalAttrs canSimulate {
           canAutomateSimply = true;
         };
       });
@@ -267,7 +267,7 @@ in rec {
           release = false;
           rustTargetInfo = seL4RustTargetInfoWithConfig { minimal = true; };
         };
-        extraPlatformArgs = lib.optionalAttrs canSimulate  {
+        extraPlatformArgs = lib.optionalAttrs canSimulate {
           canAutomateSimply = true;
         };
       });

--- a/hacking/nix/scope/world/instances/default.nix
+++ b/hacking/nix/scope/world/instances/default.nix
@@ -16,7 +16,7 @@
 , crates
 , crateUtils
 
-, mkTask, mkSeL4KernelWithPayload
+, mkTask, mkSeL4KernelLoaderWithPayload
 , embedDebugInfo
 , seL4RustTargetInfoWithConfig, defaultRustTargetInfo
 , worldConfig

--- a/hacking/nix/scope/world/instances/default.nix
+++ b/hacking/nix/scope/world/instances/default.nix
@@ -44,6 +44,7 @@ let
 
 in rec {
 
+  # TODO collect automatically
   all = lib.filter (v: v != null) [
     tests.root-task.loader
     tests.root-task.core-libs

--- a/hacking/nix/scope/world/mk-instance.nix
+++ b/hacking/nix/scope/world/mk-instance.nix
@@ -6,7 +6,7 @@
 
 { lib, hostPlatform, buildPackages
 , writeScript, linkFarm
-, mkSeL4KernelWithPayload
+, mkSeL4KernelLoaderWithPayload
 , worldConfig
 , seL4ForBoot
 
@@ -31,7 +31,7 @@ let
 
     let
 
-      loader = mkSeL4KernelWithPayload {
+      loader = mkSeL4KernelLoaderWithPayload {
         appELF = rootTask.elf;
       };
 

--- a/hacking/nix/scope/worlds.nix
+++ b/hacking/nix/scope/worlds.nix
@@ -37,7 +37,7 @@ in rec {
             , hypervisor ? false
             , cpu ? "cortex-a57"
             , isMicrokit ? false
-            , mkSeL4KernelWithPayloadArgs ? loader: [ "-kernel" loader ]
+            , mkSeL4KernelLoaderWithPayloadArgs ? loader: [ "-kernel" loader ]
             }:
             let
               numCores = if smp then "2" else "1";
@@ -72,7 +72,7 @@ in rec {
                       "-cpu" cpu "-smp" numCores "-m" "1024"
                       "-nographic"
                       "-serial" "mon:stdio"
-                  ] ++ mkSeL4KernelWithPayloadArgs loader;
+                  ] ++ mkSeL4KernelLoaderWithPayloadArgs loader;
                 };
               };
         in rec {
@@ -85,7 +85,7 @@ in rec {
             mcs = true;
             isMicrokit = true;
             cpu = "cortex-a53";
-            mkSeL4KernelWithPayloadArgs = loader: [ "-device" "loader,file=${loader},addr=0x70000000,cpu-num=0" ];
+            mkSeL4KernelLoaderWithPayloadArgs = loader: [ "-device" "loader,file=${loader},addr=0x70000000,cpu-num=0" ];
           };
         };
 

--- a/hacking/nix/top-level/default.nix
+++ b/hacking/nix/top-level/default.nix
@@ -17,16 +17,16 @@ in {
   worldsForEverythingInstances = [
     pkgs.host.aarch64.none.this.worlds.default
     pkgs.host.aarch64.none.this.worlds.qemu-arm-virt.microkit
-    pkgs.host.riscv64.none.this.worlds.default
-    pkgs.host.riscv32.none.this.worlds.default
+    pkgs.host.riscv64.default.none.this.worlds.default
+    pkgs.host.riscv32.default.none.this.worlds.default
     pkgs.host.x86_64.none.this.worlds.default
   ];
 
   sel4testInstances = (lib.mapAttrs (k: v: v.this.sel4test.automate) {
     aarch64 = pkgs.host.aarch64.none;
     aarch32 = pkgs.host.aarch32.none;
-    riscv64 = pkgs.host.riscv64.none;
-    riscv32 = pkgs.host.riscv32.none;
+    riscv64 = pkgs.host.riscv64.default.none;
+    riscv32 = pkgs.host.riscv32.default.none;
     # TODO figure out why none doesn't build
     x86_64 = pkgs.host.x86_64.linux;
     ia32 = pkgs.host.ia32.linux; # no rust support yet
@@ -35,7 +35,6 @@ in {
   sel4testInstancesList = lib.attrValues sel4testInstances;
 
   prerequisites = aggregate "prerequisites" [
-    pkgs.host.riscv64.none.gccMultiStdenvGeneric
     pkgs.build.this.qemuForSeL4
     pkgs.build.this.capdl-tool
     pkgs.build.this.vendoredTopLevelLockfile.vendoredSourcesDirectory
@@ -54,6 +53,11 @@ in {
 
     pkgs.host.aarch32.none.this.worlds.default.seL4
     pkgs.host.ia32.none.this.worlds.default.seL4
+
+    pkgs.host.riscv64.imac.none.stdenv
+    pkgs.host.riscv64.gc.none.stdenv
+    pkgs.host.riscv32.imac.none.stdenv
+    pkgs.host.riscv32.imafc.none.stdenv
 
     example
     example-rpi4-b-4gb
@@ -138,11 +142,11 @@ in {
 
   worlds = lib.fix (self: {
     default = self.aarch64.default;
-  } // lib.listToAttrs
-    (lib.forEach
-      [ "aarch64" "aarch32" "riscv64" "riscv32" "x86_64" "i386" ]
-      (arch: lib.nameValuePair arch (pkgs.host.${arch}.none.this.worlds)))
-  );
+  } // lib.mapAttrs (_: arch: arch.none.this.worlds) {
+    inherit (pkgs.host) aarch64 aarch32 x86_64 i386;
+    riscv64 = pkgs.host.riscv64.default;
+    riscv32 = pkgs.host.riscv32.default;
+  });
 
   example = worlds.default.instances.examples.root-task.example-root-task.simulate;
 

--- a/hacking/nix/top-level/docs/default.nix
+++ b/hacking/nix/top-level/docs/default.nix
@@ -39,12 +39,12 @@ let
         minimal = true;
       }
       { id = "riscv64-root-task";
-        world = pkgs.host.riscv64.none.this.worlds.default;
+        world = pkgs.host.riscv64.default.none.this.worlds.default;
         runtime = "sel4-root-task";
         minimal = false;
       }
       { id = "riscv32-root-task";
-        world = pkgs.host.riscv32.none.this.worlds.default;
+        world = pkgs.host.riscv32.default.none.this.worlds.default;
         runtime = "sel4-root-task";
         minimal = false;
       }

--- a/support/targets/riscv64gc-sel4-minimal.json
+++ b/support/targets/riscv64gc-sel4-minimal.json
@@ -1,0 +1,22 @@
+{
+  "arch": "riscv64",
+  "code-model": "medium",
+  "cpu": "generic-rv64",
+  "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128",
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "env": "sel4",
+  "exe-suffix": ".elf",
+  "features": "+m,+a,+f,+d,+c",
+  "linker": "rust-lld",
+  "linker-flavor": "ld.lld",
+  "llvm-abiname": "lp64d",
+  "llvm-target": "riscv64",
+  "max-atomic-width": 64,
+  "panic-strategy": "abort",
+  "relocation-model": "static",
+  "supported-sanitizers": [
+    "kernel-address"
+  ],
+  "target-pointer-width": "64"
+}

--- a/support/targets/riscv64gc-sel4.json
+++ b/support/targets/riscv64gc-sel4.json
@@ -1,0 +1,21 @@
+{
+  "arch": "riscv64",
+  "code-model": "medium",
+  "cpu": "generic-rv64",
+  "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128",
+  "emit-debug-gdb-scripts": false,
+  "env": "sel4",
+  "exe-suffix": ".elf",
+  "features": "+m,+a,+f,+d,+c",
+  "has-thread-local": true,
+  "linker": "rust-lld",
+  "linker-flavor": "ld.lld",
+  "llvm-abiname": "lp64d",
+  "llvm-target": "riscv64",
+  "max-atomic-width": 64,
+  "relocation-model": "static",
+  "supported-sanitizers": [
+    "kernel-address"
+  ],
+  "target-pointer-width": "64"
+}


### PR DESCRIPTION
Note: incompatible with the upstream `cc` crate until something like https://github.com/rust-lang/cc-rs/pull/796 lands.