### PR TITLE
Remove usage of unstable proc macro features

### DIFF
--- a/crates/sel4-capdl-initializer/types/src/lib.rs
+++ b/crates/sel4-capdl-initializer/types/src/lib.rs
@@ -6,8 +6,6 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(never_type)]
-#![feature(proc_macro_hygiene)]
-#![feature(stmt_expr_attributes)]
 #![feature(unwrap_infallible)]
 
 #[cfg(feature = "alloc")]

--- a/crates/sel4-capdl-initializer/types/src/when_sel4.rs
+++ b/crates/sel4-capdl-initializer/types/src/when_sel4.rs
@@ -10,8 +10,7 @@ use crate::{cap, Badge, Cap, FillEntryContentBootInfoId, Object, Rights};
 
 impl<'a, D, M> Object<'a, D, M> {
     pub fn blueprint(&self) -> Option<ObjectBlueprint> {
-        Some({
-            #[sel4::sel4_cfg_match]
+        Some(sel4::sel4_cfg_wrap_match! {
             match self {
                 Object::Untyped(obj) => ObjectBlueprint::Untyped {
                     size_bits: obj.size_bits,

--- a/crates/sel4-kernel-loader/src/arch/mod.rs
+++ b/crates/sel4-kernel-loader/src/arch/mod.rs
@@ -4,16 +4,24 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
-use sel4_config::sel4_cfg;
+use sel4_config::sel4_cfg_if;
 use sel4_kernel_loader_payload_types::PayloadInfo;
 
-#[sel4_cfg(ARCH_AARCH64)]
-#[path = "aarch64/mod.rs"]
-mod imp;
+sel4_cfg_if! {
+    if #[cfg(ARCH_AARCH64)] {
+        #[path = "aarch64/mod.rs"]
+        mod imp;
+    } else if #[cfg(any(ARCH_RISCV64, ARCH_RISCV32))] {
+        #[path = "riscv/mod.rs"]
+        mod imp;
+    }
+}
 
-#[sel4_cfg(any(ARCH_RISCV64, ARCH_RISCV32))]
-#[path = "riscv/mod.rs"]
-mod imp;
+// HACK for rustfmt
+#[cfg(any())]
+mod aarch64;
+#[cfg(any())]
+mod riscv;
 
 pub(crate) use imp::*;
 

--- a/crates/sel4-kernel-loader/src/main.rs
+++ b/crates/sel4-kernel-loader/src/main.rs
@@ -6,7 +6,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(proc_macro_hygiene)]
 #![allow(dead_code)]
 #![allow(unreachable_code)]
 #![allow(clippy::reversed_empty_ranges)]

--- a/crates/sel4-kernel-loader/src/plat/mod.rs
+++ b/crates/sel4-kernel-loader/src/plat/mod.rs
@@ -4,19 +4,28 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
-use sel4_config::sel4_cfg;
+use sel4_config::sel4_cfg_if;
 
-#[sel4_cfg(all(ARCH_AARCH64, PLAT_QEMU_ARM_VIRT))]
-#[path = "qemu_arm_virt/mod.rs"]
-mod imp;
+sel4_cfg_if! {
+    if #[cfg(all(ARCH_AARCH64, PLAT_QEMU_ARM_VIRT))] {
+        #[path = "qemu_arm_virt/mod.rs"]
+        mod imp;
+    } else if #[cfg(all(ARCH_AARCH64, PLAT_BCM2711))] {
+        #[path = "bcm2711/mod.rs"]
+        mod imp;
+    } else if #[cfg(all(any(ARCH_RISCV64, ARCH_RISCV32), any(PLAT_SPIKE, PLAT_QEMU_RISCV_VIRT)))] {
+        #[path = "riscv_generic/mod.rs"]
+        mod imp;
+    }
+}
 
-#[sel4_cfg(all(ARCH_AARCH64, PLAT_BCM2711))]
-#[path = "bcm2711/mod.rs"]
-mod imp;
-
-#[sel4_cfg(all(any(ARCH_RISCV64, ARCH_RISCV32), any(PLAT_SPIKE, PLAT_QEMU_RISCV_VIRT)))]
-#[path = "riscv_generic/mod.rs"]
-mod imp;
+// HACK for rustfmt
+#[cfg(any())]
+mod bcm2711;
+#[cfg(any())]
+mod qemu_arm_virt;
+#[cfg(any())]
+mod riscv_generic;
 
 #[allow(unused_imports)]
 pub(crate) use imp::*;

--- a/crates/sel4/config/generic/macro-impls/src/attr_macros.rs
+++ b/crates/sel4/config/generic/macro-impls/src/attr_macros.rs
@@ -85,6 +85,14 @@ impl<'a> Impls<'a> {
 
     pub fn cfg_match_impl(&self, input: TokenStream, item: TokenStream) -> TokenStream {
         ensure_empty!(input);
+        self.cfg_match_impl_inner(item)
+    }
+
+    pub fn cfg_wrap_match_impl(&self, item: TokenStream) -> TokenStream {
+        self.cfg_match_impl_inner(item)
+    }
+
+    fn cfg_match_impl_inner(&self, item: TokenStream) -> TokenStream {
         let mut match_expr = parse_or_return!(item as syn::ExprMatch);
         let mut helper = Helper::new(self);
         match_expr

--- a/crates/sel4/config/macros/src/lib.rs
+++ b/crates/sel4/config/macros/src/lib.rs
@@ -43,6 +43,11 @@ pub fn sel4_cfg_match(input: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 #[proc_macro]
+pub fn sel4_cfg_wrap_match(item: TokenStream) -> TokenStream {
+    get_impls().cfg_wrap_match_impl(item.into()).into()
+}
+
+#[proc_macro]
 pub fn sel4_cfg_if(toks: TokenStream) -> TokenStream {
     get_impls().cfg_if_impl(toks.into()).into()
 }

--- a/crates/sel4/src/arch/arm/arch/aarch32/mod.rs
+++ b/crates/sel4/src/arch/arm/arch/aarch32/mod.rs
@@ -8,7 +8,14 @@ mod fault;
 mod object;
 mod user_context;
 
-#[sel4_config::sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
+sel4_config::sel4_cfg_if! {
+    if #[cfg(ARM_HYPERVISOR_SUPPORT)] {
+        mod vcpu_reg;
+    }
+}
+
+// HACK for rustfmt
+#[cfg(any())]
 mod vcpu_reg;
 
 pub(crate) mod top_level {

--- a/crates/sel4/src/arch/arm/arch/aarch64/mod.rs
+++ b/crates/sel4/src/arch/arm/arch/aarch64/mod.rs
@@ -8,7 +8,14 @@ mod fault;
 mod object;
 mod user_context;
 
-#[sel4_config::sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
+sel4_config::sel4_cfg_if! {
+    if #[cfg(ARM_HYPERVISOR_SUPPORT)] {
+        mod vcpu_reg;
+    }
+}
+
+// HACK for rustfmt
+#[cfg(any())]
 mod vcpu_reg;
 
 pub(crate) mod top_level {

--- a/crates/sel4/src/arch/arm/arch/mod.rs
+++ b/crates/sel4/src/arch/arm/arch/mod.rs
@@ -4,14 +4,22 @@
 // SPDX-License-Identifier: MIT
 //
 
-use sel4_config::sel4_cfg;
+use sel4_config::sel4_cfg_if;
 
-#[sel4_cfg(ARCH_AARCH64)]
-#[path = "aarch64/mod.rs"]
-mod imp;
+sel4_cfg_if! {
+    if #[cfg(ARCH_AARCH64)] {
+        #[path = "aarch64/mod.rs"]
+        mod imp;
+    } else if #[cfg(ARCH_AARCH32)] {
+        #[path = "aarch32/mod.rs"]
+        mod imp;
+    }
+}
 
-#[sel4_cfg(ARCH_AARCH32)]
-#[path = "aarch32/mod.rs"]
-mod imp;
+// HACK for rustfmt
+#[cfg(any())]
+mod aarch32;
+#[cfg(any())]
+mod aarch64;
 
 pub(crate) use imp::*;

--- a/crates/sel4/src/arch/arm/fault.rs
+++ b/crates/sel4/src/arch/arm/fault.rs
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-use sel4_config::{sel4_cfg, sel4_cfg_enum, sel4_cfg_if, sel4_cfg_match};
+use sel4_config::{sel4_cfg, sel4_cfg_enum, sel4_cfg_if, sel4_cfg_wrap_match};
 
 use crate::{declare_fault_newtype, sys, Word};
 
@@ -46,32 +46,33 @@ pub enum Fault {
 
 impl Fault {
     pub fn from_sys(raw: sys::seL4_Fault) -> Self {
-        #[sel4_cfg_match]
-        match raw.splay() {
-            sys::seL4_Fault_Splayed::NullFault(inner) => {
-                Self::NullFault(NullFault::from_inner(inner))
-            }
-            sys::seL4_Fault_Splayed::CapFault(inner) => Self::CapFault(CapFault::from_inner(inner)),
-            sys::seL4_Fault_Splayed::UnknownSyscall(inner) => {
-                Self::UnknownSyscall(UnknownSyscall::from_inner(inner))
-            }
-            sys::seL4_Fault_Splayed::UserException(inner) => {
-                Self::UserException(UserException::from_inner(inner))
-            }
-            sys::seL4_Fault_Splayed::VMFault(inner) => Self::VMFault(VMFault::from_inner(inner)),
-            #[sel4_cfg(KERNEL_MCS)]
-            sys::seL4_Fault_Splayed::Timeout(inner) => Self::Timeout(Timeout::from_inner(inner)),
-            #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
-            sys::seL4_Fault_Splayed::VGICMaintenance(inner) => {
-                Self::VGICMaintenance(VGICMaintenance::from_inner(inner))
-            }
-            #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
-            sys::seL4_Fault_Splayed::VCPUFault(inner) => {
-                Self::VCPUFault(VCPUFault::from_inner(inner))
-            }
-            #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
-            sys::seL4_Fault_Splayed::VPPIEvent(inner) => {
-                Self::VPPIEvent(VPPIEvent::from_inner(inner))
+        sel4_cfg_wrap_match! {
+            match raw.splay() {
+                sys::seL4_Fault_Splayed::NullFault(inner) => {
+                    Self::NullFault(NullFault::from_inner(inner))
+                }
+                sys::seL4_Fault_Splayed::CapFault(inner) => Self::CapFault(CapFault::from_inner(inner)),
+                sys::seL4_Fault_Splayed::UnknownSyscall(inner) => {
+                    Self::UnknownSyscall(UnknownSyscall::from_inner(inner))
+                }
+                sys::seL4_Fault_Splayed::UserException(inner) => {
+                    Self::UserException(UserException::from_inner(inner))
+                }
+                sys::seL4_Fault_Splayed::VMFault(inner) => Self::VMFault(VMFault::from_inner(inner)),
+                #[sel4_cfg(KERNEL_MCS)]
+                sys::seL4_Fault_Splayed::Timeout(inner) => Self::Timeout(Timeout::from_inner(inner)),
+                #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
+                sys::seL4_Fault_Splayed::VGICMaintenance(inner) => {
+                    Self::VGICMaintenance(VGICMaintenance::from_inner(inner))
+                }
+                #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
+                sys::seL4_Fault_Splayed::VCPUFault(inner) => {
+                    Self::VCPUFault(VCPUFault::from_inner(inner))
+                }
+                #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
+                sys::seL4_Fault_Splayed::VPPIEvent(inner) => {
+                    Self::VPPIEvent(VPPIEvent::from_inner(inner))
+                }
             }
         }
     }

--- a/crates/sel4/src/arch/arm/object.rs
+++ b/crates/sel4/src/arch/arm/object.rs
@@ -7,7 +7,7 @@
 
 use core::ffi::c_uint;
 
-use sel4_config::{sel4_cfg_enum, sel4_cfg_match};
+use sel4_config::{sel4_cfg_enum, sel4_cfg_wrap_match};
 
 use crate::{
     const_helpers::u32_into_usize, sys, ObjectBlueprint, ObjectBlueprintSeL4Arch, ObjectType,
@@ -34,14 +34,15 @@ pub enum ObjectTypeArm {
 
 impl ObjectTypeArm {
     pub(crate) const fn into_sys(self) -> c_uint {
-        #[sel4_cfg_match]
-        match self {
-            Self::SmallPage => sys::_object::seL4_ARM_SmallPageObject,
-            Self::LargePage => sys::_object::seL4_ARM_LargePageObject,
-            Self::PT => sys::_object::seL4_ARM_PageTableObject,
-            #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
-            Self::VCPU => sys::_object::seL4_ARM_VCPUObject,
-            Self::SeL4Arch(sel4_arch) => sel4_arch.into_sys(),
+        sel4_cfg_wrap_match! {
+            match self {
+                Self::SmallPage => sys::_object::seL4_ARM_SmallPageObject,
+                Self::LargePage => sys::_object::seL4_ARM_LargePageObject,
+                Self::PT => sys::_object::seL4_ARM_PageTableObject,
+                #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
+                Self::VCPU => sys::_object::seL4_ARM_VCPUObject,
+                Self::SeL4Arch(sel4_arch) => sel4_arch.into_sys(),
+            }
         }
     }
 }
@@ -72,26 +73,28 @@ pub enum ObjectBlueprintArm {
 
 impl ObjectBlueprintArm {
     pub(crate) const fn ty(self) -> ObjectTypeArch {
-        #[sel4_cfg_match]
-        match self {
-            Self::SmallPage => ObjectTypeArm::SmallPage,
-            Self::LargePage => ObjectTypeArm::LargePage,
-            Self::PT => ObjectTypeArm::PT,
-            #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
-            Self::VCPU => ObjectTypeArm::VCPU,
-            Self::SeL4Arch(sel4_arch) => ObjectTypeArch::SeL4Arch(sel4_arch.ty()),
+        sel4_cfg_wrap_match! {
+            match self {
+                Self::SmallPage => ObjectTypeArm::SmallPage,
+                Self::LargePage => ObjectTypeArm::LargePage,
+                Self::PT => ObjectTypeArm::PT,
+                #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
+                Self::VCPU => ObjectTypeArm::VCPU,
+                Self::SeL4Arch(sel4_arch) => ObjectTypeArch::SeL4Arch(sel4_arch.ty()),
+            }
         }
     }
 
     pub(crate) const fn physical_size_bits(self) -> usize {
-        #[sel4_cfg_match]
-        match self {
-            Self::SmallPage => u32_into_usize(sys::seL4_PageBits),
-            Self::LargePage => u32_into_usize(sys::seL4_LargePageBits),
-            Self::PT => u32_into_usize(sys::seL4_PageTableBits),
-            #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
-            Self::VCPU => u32_into_usize(sys::seL4_VCPUBits),
-            Self::SeL4Arch(sel4_arch) => sel4_arch.physical_size_bits(),
+        sel4_cfg_wrap_match! {
+            match self {
+                Self::SmallPage => u32_into_usize(sys::seL4_PageBits),
+                Self::LargePage => u32_into_usize(sys::seL4_LargePageBits),
+                Self::PT => u32_into_usize(sys::seL4_PageTableBits),
+                #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)]
+                Self::VCPU => u32_into_usize(sys::seL4_VCPUBits),
+                Self::SeL4Arch(sel4_arch) => sel4_arch.physical_size_bits(),
+            }
         }
     }
 }

--- a/crates/sel4/src/arch/arm/vspace.rs
+++ b/crates/sel4/src/arch/arm/vspace.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-use sel4_config::{sel4_cfg, sel4_cfg_enum, sel4_cfg_match};
+use sel4_config::{sel4_cfg, sel4_cfg_enum, sel4_cfg_wrap_match};
 
 use crate::{cap_type, sys, FrameType, ObjectBlueprint, ObjectBlueprintArm, SizedFrameType};
 
@@ -23,14 +23,15 @@ pub enum FrameSize {
 
 impl FrameSize {
     pub const fn blueprint(self) -> ObjectBlueprint {
-        #[sel4_cfg_match]
-        match self {
-            Self::Small => ObjectBlueprint::Arch(ObjectBlueprintArm::SmallPage),
-            Self::Large => ObjectBlueprint::Arch(ObjectBlueprintArm::LargePage),
-            #[sel4_cfg(ARCH_AARCH64)]
-            Self::Huge => ObjectBlueprint::Arch(ObjectBlueprintArm::SeL4Arch(
-                ObjectBlueprintAArch64::HugePage,
-            )),
+        sel4_cfg_wrap_match! {
+            match self {
+                Self::Small => ObjectBlueprint::Arch(ObjectBlueprintArm::SmallPage),
+                Self::Large => ObjectBlueprint::Arch(ObjectBlueprintArm::LargePage),
+                #[sel4_cfg(ARCH_AARCH64)]
+                Self::Huge => ObjectBlueprint::Arch(ObjectBlueprintArm::SeL4Arch(
+                    ObjectBlueprintAArch64::HugePage,
+                )),
+            }
         }
     }
 

--- a/crates/sel4/src/arch/mod.rs
+++ b/crates/sel4/src/arch/mod.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-use sel4_config::sel4_cfg;
+use sel4_config::sel4_cfg_if;
 
 // [TODO]
 // sel4-config doesn't yet play nicely with:
@@ -12,16 +12,25 @@ use sel4_config::sel4_cfg;
 //   - ARCH_RISCV
 //   - ARCH_X86
 
-#[sel4_cfg(any(ARCH_AARCH32, ARCH_AARCH64))]
-#[path = "arm/mod.rs"]
-mod imp;
+sel4_cfg_if! {
+    if #[cfg(any(ARCH_AARCH32, ARCH_AARCH64))] {
+        #[path = "arm/mod.rs"]
+        mod imp;
+    } else if #[cfg(any(ARCH_IA32, ARCH_X86_64))] {
+        #[path = "x86/mod.rs"]
+        mod imp;
+    } else if #[cfg(any(ARCH_RISCV32, ARCH_RISCV64))] {
+        #[path = "riscv/mod.rs"]
+        mod imp;
+    }
+}
 
-#[sel4_cfg(any(ARCH_IA32, ARCH_X86_64))]
-#[path = "x86/mod.rs"]
-mod imp;
-
-#[sel4_cfg(any(ARCH_RISCV32, ARCH_RISCV64))]
-#[path = "riscv/mod.rs"]
-mod imp;
+// HACK for rustfmt
+#[cfg(any())]
+mod arm;
+#[cfg(any())]
+mod riscv;
+#[cfg(any())]
+mod x86;
 
 pub(crate) use imp::*;

--- a/crates/sel4/src/arch/riscv/fault.rs
+++ b/crates/sel4/src/arch/riscv/fault.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-use sel4_config::{sel4_cfg, sel4_cfg_enum, sel4_cfg_match};
+use sel4_config::{sel4_cfg, sel4_cfg_enum, sel4_cfg_wrap_match};
 
 use crate::{declare_fault_newtype, sys};
 
@@ -31,21 +31,22 @@ pub enum Fault {
 
 impl Fault {
     pub fn from_sys(raw: sys::seL4_Fault) -> Self {
-        #[sel4_cfg_match]
-        match raw.splay() {
-            sys::seL4_Fault_Splayed::NullFault(inner) => {
-                Self::NullFault(NullFault::from_inner(inner))
+        sel4_cfg_wrap_match! {
+            match raw.splay() {
+                sys::seL4_Fault_Splayed::NullFault(inner) => {
+                    Self::NullFault(NullFault::from_inner(inner))
+                }
+                sys::seL4_Fault_Splayed::CapFault(inner) => Self::CapFault(CapFault::from_inner(inner)),
+                sys::seL4_Fault_Splayed::UnknownSyscall(inner) => {
+                    Self::UnknownSyscall(UnknownSyscall::from_inner(inner))
+                }
+                sys::seL4_Fault_Splayed::UserException(inner) => {
+                    Self::UserException(UserException::from_inner(inner))
+                }
+                sys::seL4_Fault_Splayed::VMFault(inner) => Self::VMFault(VMFault::from_inner(inner)),
+                #[sel4_cfg(KERNEL_MCS)]
+                sys::seL4_Fault_Splayed::Timeout(inner) => Self::Timeout(Timeout::from_inner(inner)),
             }
-            sys::seL4_Fault_Splayed::CapFault(inner) => Self::CapFault(CapFault::from_inner(inner)),
-            sys::seL4_Fault_Splayed::UnknownSyscall(inner) => {
-                Self::UnknownSyscall(UnknownSyscall::from_inner(inner))
-            }
-            sys::seL4_Fault_Splayed::UserException(inner) => {
-                Self::UserException(UserException::from_inner(inner))
-            }
-            sys::seL4_Fault_Splayed::VMFault(inner) => Self::VMFault(VMFault::from_inner(inner)),
-            #[sel4_cfg(KERNEL_MCS)]
-            sys::seL4_Fault_Splayed::Timeout(inner) => Self::Timeout(Timeout::from_inner(inner)),
         }
     }
 }

--- a/crates/sel4/src/arch/riscv/object.rs
+++ b/crates/sel4/src/arch/riscv/object.rs
@@ -6,7 +6,7 @@
 
 use core::ffi::c_uint;
 
-use sel4_config::{sel4_cfg_enum, sel4_cfg_match};
+use sel4_config::{sel4_cfg_enum, sel4_cfg_wrap_match};
 
 use crate::{const_helpers::u32_into_usize, sys};
 
@@ -26,13 +26,14 @@ pub enum ObjectTypeRISCV {
 
 impl ObjectTypeRISCV {
     pub(crate) const fn into_sys(self) -> c_uint {
-        #[sel4_cfg_match]
-        match self {
-            Self::_4KPage => sys::_object::seL4_RISCV_4K_Page,
-            Self::MegaPage => sys::_object::seL4_RISCV_Mega_Page,
-            #[sel4_cfg(any(PT_LEVELS = "3", PT_LEVELS = "4"))]
-            Self::GigaPage => sys::_mode_object::seL4_RISCV_Giga_Page,
-            Self::PageTable => sys::_object::seL4_RISCV_PageTableObject,
+        sel4_cfg_wrap_match! {
+            match self {
+                Self::_4KPage => sys::_object::seL4_RISCV_4K_Page,
+                Self::MegaPage => sys::_object::seL4_RISCV_Mega_Page,
+                #[sel4_cfg(any(PT_LEVELS = "3", PT_LEVELS = "4"))]
+                Self::GigaPage => sys::_mode_object::seL4_RISCV_Giga_Page,
+                Self::PageTable => sys::_object::seL4_RISCV_PageTableObject,
+            }
         }
     }
 }
@@ -49,24 +50,26 @@ pub enum ObjectBlueprintRISCV {
 
 impl ObjectBlueprintRISCV {
     pub(crate) const fn ty(self) -> ObjectTypeRISCV {
-        #[sel4_cfg_match]
-        match self {
-            Self::_4KPage => ObjectTypeRISCV::_4KPage,
-            Self::MegaPage => ObjectTypeRISCV::MegaPage,
-            #[sel4_cfg(any(PT_LEVELS = "3", PT_LEVELS = "4"))]
-            Self::GigaPage => ObjectTypeRISCV::GigaPage,
-            Self::PageTable => ObjectTypeRISCV::PageTable,
+        sel4_cfg_wrap_match! {
+            match self {
+                Self::_4KPage => ObjectTypeRISCV::_4KPage,
+                Self::MegaPage => ObjectTypeRISCV::MegaPage,
+                #[sel4_cfg(any(PT_LEVELS = "3", PT_LEVELS = "4"))]
+                Self::GigaPage => ObjectTypeRISCV::GigaPage,
+                Self::PageTable => ObjectTypeRISCV::PageTable,
+            }
         }
     }
 
     pub(crate) const fn physical_size_bits(self) -> usize {
-        #[sel4_cfg_match]
-        match self {
-            Self::_4KPage => u32_into_usize(sys::seL4_PageBits),
-            Self::MegaPage => u32_into_usize(sys::seL4_LargePageBits),
-            #[sel4_cfg(any(PT_LEVELS = "3", PT_LEVELS = "4"))]
-            Self::GigaPage => u32_into_usize(sys::seL4_HugePageBits),
-            Self::PageTable => u32_into_usize(sys::seL4_PageTableBits),
+        sel4_cfg_wrap_match! {
+            match self {
+                Self::_4KPage => u32_into_usize(sys::seL4_PageBits),
+                Self::MegaPage => u32_into_usize(sys::seL4_LargePageBits),
+                #[sel4_cfg(any(PT_LEVELS = "3", PT_LEVELS = "4"))]
+                Self::GigaPage => u32_into_usize(sys::seL4_HugePageBits),
+                Self::PageTable => u32_into_usize(sys::seL4_PageTableBits),
+            }
         }
     }
 }

--- a/crates/sel4/src/arch/riscv/vspace.rs
+++ b/crates/sel4/src/arch/riscv/vspace.rs
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+use sel4_config::sel4_cfg_wrap_match;
+
 #[allow(unused_imports)]
 use crate::{cap_type, sys, FrameType, ObjectBlueprint, ObjectBlueprintRISCV, SizedFrameType};
 
@@ -18,12 +20,13 @@ pub enum FrameSize {
 
 impl FrameSize {
     pub const fn blueprint(self) -> ObjectBlueprint {
-        #[sel4_config::sel4_cfg_match]
-        match self {
-            FrameSize::_4K => ObjectBlueprint::Arch(ObjectBlueprintRISCV::_4KPage),
-            FrameSize::Mega => ObjectBlueprint::Arch(ObjectBlueprintRISCV::MegaPage),
-            #[sel4_cfg(any(PT_LEVELS = "3", PT_LEVELS = "4"))]
-            FrameSize::Giga => ObjectBlueprint::Arch(ObjectBlueprintRISCV::GigaPage),
+        sel4_cfg_wrap_match! {
+            match self {
+                FrameSize::_4K => ObjectBlueprint::Arch(ObjectBlueprintRISCV::_4KPage),
+                FrameSize::Mega => ObjectBlueprint::Arch(ObjectBlueprintRISCV::MegaPage),
+                #[sel4_cfg(any(PT_LEVELS = "3", PT_LEVELS = "4"))]
+                FrameSize::Giga => ObjectBlueprint::Arch(ObjectBlueprintRISCV::GigaPage),
+            }
         }
     }
 

--- a/crates/sel4/src/arch/x86/arch/mod.rs
+++ b/crates/sel4/src/arch/x86/arch/mod.rs
@@ -4,10 +4,17 @@
 // SPDX-License-Identifier: MIT
 //
 
-use sel4_config::sel4_cfg;
+use sel4_config::sel4_cfg_if;
 
-#[sel4_cfg(ARCH_X86_64)]
-#[path = "x64/mod.rs"]
-mod imp;
+sel4_cfg_if! {
+    if #[cfg(ARCH_X86_64)] {
+        #[path = "x64/mod.rs"]
+        mod imp;
+    }
+}
+
+// HACK for rustfmt
+#[cfg(any())]
+mod x64;
 
 pub(crate) use imp::*;

--- a/crates/sel4/src/arch/x86/fault.rs
+++ b/crates/sel4/src/arch/x86/fault.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-use sel4_config::{sel4_cfg, sel4_cfg_enum, sel4_cfg_match};
+use sel4_config::{sel4_cfg, sel4_cfg_enum, sel4_cfg_wrap_match};
 
 use crate::{declare_fault_newtype, sys};
 
@@ -31,21 +31,22 @@ pub enum Fault {
 
 impl Fault {
     pub fn from_sys(raw: sys::seL4_Fault) -> Self {
-        #[sel4_cfg_match]
-        match raw.splay() {
-            sys::seL4_Fault_Splayed::NullFault(inner) => {
-                Self::NullFault(NullFault::from_inner(inner))
+        sel4_cfg_wrap_match! {
+            match raw.splay() {
+                sys::seL4_Fault_Splayed::NullFault(inner) => {
+                    Self::NullFault(NullFault::from_inner(inner))
+                }
+                sys::seL4_Fault_Splayed::CapFault(inner) => Self::CapFault(CapFault::from_inner(inner)),
+                sys::seL4_Fault_Splayed::UnknownSyscall(inner) => {
+                    Self::UnknownSyscall(UnknownSyscall::from_inner(inner))
+                }
+                sys::seL4_Fault_Splayed::UserException(inner) => {
+                    Self::UserException(UserException::from_inner(inner))
+                }
+                sys::seL4_Fault_Splayed::VMFault(inner) => Self::VMFault(VMFault::from_inner(inner)),
+                #[sel4_cfg(KERNEL_MCS)]
+                sys::seL4_Fault_Splayed::Timeout(inner) => Self::Timeout(Timeout::from_inner(inner)),
             }
-            sys::seL4_Fault_Splayed::CapFault(inner) => Self::CapFault(CapFault::from_inner(inner)),
-            sys::seL4_Fault_Splayed::UnknownSyscall(inner) => {
-                Self::UnknownSyscall(UnknownSyscall::from_inner(inner))
-            }
-            sys::seL4_Fault_Splayed::UserException(inner) => {
-                Self::UserException(UserException::from_inner(inner))
-            }
-            sys::seL4_Fault_Splayed::VMFault(inner) => Self::VMFault(VMFault::from_inner(inner)),
-            #[sel4_cfg(KERNEL_MCS)]
-            sys::seL4_Fault_Splayed::Timeout(inner) => Self::Timeout(Timeout::from_inner(inner)),
         }
     }
 }

--- a/crates/sel4/src/lib.rs
+++ b/crates/sel4/src/lib.rs
@@ -49,7 +49,7 @@
 
 pub use sel4_config::{
     self as config, sel4_cfg, sel4_cfg_bool, sel4_cfg_enum, sel4_cfg_if, sel4_cfg_match,
-    sel4_cfg_str, sel4_cfg_usize,
+    sel4_cfg_str, sel4_cfg_usize, sel4_cfg_wrap_match,
 };
 
 pub use sel4_sys as sys;

--- a/crates/sel4/src/lib.rs
+++ b/crates/sel4/src/lib.rs
@@ -42,8 +42,6 @@
 
 #![no_std]
 #![feature(cfg_target_thread_local)]
-#![feature(proc_macro_hygiene)]
-#![feature(stmt_expr_attributes)]
 #![feature(thread_local)]
 #![allow(clippy::unit_arg)]
 

--- a/crates/sel4/src/object.rs
+++ b/crates/sel4/src/object.rs
@@ -8,7 +8,7 @@
 use core::ffi::c_uint;
 
 use crate::{
-    const_helpers::u32_into_usize, sel4_cfg, sel4_cfg_enum, sel4_cfg_match, sys,
+    const_helpers::u32_into_usize, sel4_cfg, sel4_cfg_enum, sel4_cfg_wrap_match, sys,
     ObjectBlueprintArch, ObjectTypeArch,
 };
 
@@ -36,18 +36,19 @@ pub enum ObjectType {
 
 impl ObjectType {
     pub const fn into_sys(self) -> c_uint {
-        #[sel4_cfg_match]
-        match self {
-            Self::Untyped => sys::api_object::seL4_UntypedObject,
-            Self::Endpoint => sys::api_object::seL4_EndpointObject,
-            Self::Notification => sys::api_object::seL4_NotificationObject,
-            Self::CNode => sys::api_object::seL4_CapTableObject,
-            Self::TCB => sys::api_object::seL4_TCBObject,
-            #[sel4_cfg(KERNEL_MCS)]
-            Self::SchedContext => sys::api_object::seL4_SchedContextObject,
-            #[sel4_cfg(KERNEL_MCS)]
-            Self::Reply => sys::api_object::seL4_ReplyObject,
-            Self::Arch(arch) => arch.into_sys(),
+        sel4_cfg_wrap_match! {
+            match self {
+                Self::Untyped => sys::api_object::seL4_UntypedObject,
+                Self::Endpoint => sys::api_object::seL4_EndpointObject,
+                Self::Notification => sys::api_object::seL4_NotificationObject,
+                Self::CNode => sys::api_object::seL4_CapTableObject,
+                Self::TCB => sys::api_object::seL4_TCBObject,
+                #[sel4_cfg(KERNEL_MCS)]
+                Self::SchedContext => sys::api_object::seL4_SchedContextObject,
+                #[sel4_cfg(KERNEL_MCS)]
+                Self::Reply => sys::api_object::seL4_ReplyObject,
+                Self::Arch(arch) => arch.into_sys(),
+            }
         }
     }
 }
@@ -82,45 +83,48 @@ pub enum ObjectBlueprint {
 
 impl ObjectBlueprint {
     pub const fn ty(self) -> ObjectType {
-        #[sel4_cfg_match]
-        match self {
-            Self::Untyped { .. } => ObjectType::Untyped,
-            Self::Endpoint => ObjectType::Endpoint,
-            Self::Notification => ObjectType::Notification,
-            Self::CNode { .. } => ObjectType::CNode,
-            Self::TCB => ObjectType::TCB,
-            #[sel4_cfg(KERNEL_MCS)]
-            Self::SchedContext { .. } => ObjectType::SchedContext,
-            #[sel4_cfg(KERNEL_MCS)]
-            Self::Reply { .. } => ObjectType::Reply,
-            Self::Arch(arch) => ObjectType::Arch(arch.ty()),
+        sel4_cfg_wrap_match! {
+            match self {
+                Self::Untyped { .. } => ObjectType::Untyped,
+                Self::Endpoint => ObjectType::Endpoint,
+                Self::Notification => ObjectType::Notification,
+                Self::CNode { .. } => ObjectType::CNode,
+                Self::TCB => ObjectType::TCB,
+                #[sel4_cfg(KERNEL_MCS)]
+                Self::SchedContext { .. } => ObjectType::SchedContext,
+                #[sel4_cfg(KERNEL_MCS)]
+                Self::Reply { .. } => ObjectType::Reply,
+                Self::Arch(arch) => ObjectType::Arch(arch.ty()),
+            }
         }
     }
 
     pub const fn api_size_bits(self) -> Option<usize> {
-        #[sel4_cfg_match]
-        match self {
-            Self::Untyped { size_bits } => Some(size_bits),
-            Self::CNode { size_bits } => Some(size_bits),
-            #[sel4_cfg(KERNEL_MCS)]
-            Self::SchedContext { size_bits } => Some(size_bits),
-            _ => None,
+        sel4_cfg_wrap_match! {
+            match self {
+                Self::Untyped { size_bits } => Some(size_bits),
+                Self::CNode { size_bits } => Some(size_bits),
+                #[sel4_cfg(KERNEL_MCS)]
+                Self::SchedContext { size_bits } => Some(size_bits),
+                _ => None,
+            }
         }
     }
 
     pub const fn physical_size_bits(self) -> usize {
-        #[sel4_cfg_match]
-        match self {
-            Self::Untyped { size_bits } => size_bits,
-            Self::Endpoint => u32_into_usize(sys::seL4_EndpointBits),
-            Self::Notification => u32_into_usize(sys::seL4_NotificationBits),
-            Self::CNode { size_bits } => u32_into_usize(sys::seL4_SlotBits) + size_bits,
-            Self::TCB => u32_into_usize(sys::seL4_TCBBits),
-            #[sel4_cfg(KERNEL_MCS)]
-            Self::SchedContext { size_bits } => usize_max(MIN_SCHED_CONTEXT_BITS, size_bits),
-            #[sel4_cfg(KERNEL_MCS)]
-            Self::Reply => u32_into_usize(sys::seL4_ReplyBits),
-            Self::Arch(arch) => arch.physical_size_bits(),
+        sel4_cfg_wrap_match! {
+            match self {
+                Self::Untyped { size_bits } => size_bits,
+                Self::Endpoint => u32_into_usize(sys::seL4_EndpointBits),
+                Self::Notification => u32_into_usize(sys::seL4_NotificationBits),
+                Self::CNode { size_bits } => u32_into_usize(sys::seL4_SlotBits) + size_bits,
+                Self::TCB => u32_into_usize(sys::seL4_TCBBits),
+                #[sel4_cfg(KERNEL_MCS)]
+                Self::SchedContext { size_bits } => usize_max(MIN_SCHED_CONTEXT_BITS, size_bits),
+                #[sel4_cfg(KERNEL_MCS)]
+                Self::Reply => u32_into_usize(sys::seL4_ReplyBits),
+                Self::Arch(arch) => arch.physical_size_bits(),
+            }
         }
     }
 

--- a/crates/sel4/sys/src/fault/arch/aarch32.rs
+++ b/crates/sel4/sys/src/fault/arch/aarch32.rs
@@ -7,7 +7,7 @@
 use crate::bf::*;
 use crate::c::*;
 
-use sel4_config::sel4_cfg_match;
+use sel4_config::sel4_cfg_wrap_match;
 
 impl seL4_Fault {
     pub(crate) fn arch_get_with(
@@ -15,8 +15,7 @@ impl seL4_Fault {
         length: seL4_Word,
         f: impl Fn(core::ffi::c_ulong) -> seL4_Word,
     ) -> Option<Self> {
-        Some({
-            #[sel4_cfg_match]
+        Some(sel4_cfg_wrap_match! {
             match label {
                 seL4_Fault_tag::seL4_Fault_UnknownSyscall => {
                     assert!(length == seL4_UnknownSyscall_Msg::seL4_UnknownSyscall_Length);

--- a/crates/sel4/sys/src/fault/arch/aarch32.rs
+++ b/crates/sel4/sys/src/fault/arch/aarch32.rs
@@ -10,7 +10,11 @@ use crate::c::*;
 use sel4_config::sel4_cfg_match;
 
 impl seL4_Fault {
-    pub(crate) fn arch_get_with(label: seL4_Word, length: seL4_Word, f: impl Fn(core::ffi::c_ulong) -> seL4_Word) -> Option<Self> {
+    pub(crate) fn arch_get_with(
+        label: seL4_Word,
+        length: seL4_Word,
+        f: impl Fn(core::ffi::c_ulong) -> seL4_Word,
+    ) -> Option<Self> {
         Some({
             #[sel4_cfg_match]
             match label {
@@ -79,9 +83,7 @@ impl seL4_Fault {
                     }
                     .unsplay()
                 }
-                _ => {
-                    return None
-                }
+                _ => return None,
             }
         })
     }

--- a/crates/sel4/sys/src/fault/arch/aarch64.rs
+++ b/crates/sel4/sys/src/fault/arch/aarch64.rs
@@ -7,7 +7,7 @@
 use crate::bf::*;
 use crate::c::*;
 
-use sel4_config::sel4_cfg_match;
+use sel4_config::sel4_cfg_wrap_match;
 
 impl seL4_Fault {
     pub(crate) fn arch_get_with(
@@ -15,8 +15,7 @@ impl seL4_Fault {
         length: seL4_Word,
         f: impl Fn(core::ffi::c_ulong) -> seL4_Word,
     ) -> Option<Self> {
-        Some({
-            #[sel4_cfg_match]
+        Some(sel4_cfg_wrap_match! {
             match label {
                 seL4_Fault_tag::seL4_Fault_UnknownSyscall => {
                     assert!(length == seL4_UnknownSyscall_Msg::seL4_UnknownSyscall_Length);

--- a/crates/sel4/sys/src/fault/arch/aarch64.rs
+++ b/crates/sel4/sys/src/fault/arch/aarch64.rs
@@ -10,7 +10,11 @@ use crate::c::*;
 use sel4_config::sel4_cfg_match;
 
 impl seL4_Fault {
-    pub(crate) fn arch_get_with(label: seL4_Word, length: seL4_Word, f: impl Fn(core::ffi::c_ulong) -> seL4_Word) -> Option<Self> {
+    pub(crate) fn arch_get_with(
+        label: seL4_Word,
+        length: seL4_Word,
+        f: impl Fn(core::ffi::c_ulong) -> seL4_Word,
+    ) -> Option<Self> {
         Some({
             #[sel4_cfg_match]
             match label {
@@ -79,9 +83,7 @@ impl seL4_Fault {
                     }
                     .unsplay()
                 }
-                _ => {
-                    return None
-                }
+                _ => return None,
             }
         })
     }

--- a/crates/sel4/sys/src/fault/arch/mod.rs
+++ b/crates/sel4/sys/src/fault/arch/mod.rs
@@ -21,3 +21,13 @@ sel4_cfg_if! {
         mod imp;
     }
 }
+
+// HACK for rustfmt
+#[cfg(any())]
+mod aarch32;
+#[cfg(any())]
+mod aarch64;
+#[cfg(any())]
+mod riscv;
+#[cfg(any())]
+mod x86_64;

--- a/crates/sel4/sys/src/fault/arch/riscv.rs
+++ b/crates/sel4/sys/src/fault/arch/riscv.rs
@@ -7,7 +7,7 @@
 use crate::bf::*;
 use crate::c::*;
 
-use sel4_config::sel4_cfg_match;
+use sel4_config::sel4_cfg_wrap_match;
 
 impl seL4_Fault {
     pub(crate) fn arch_get_with(
@@ -17,8 +17,7 @@ impl seL4_Fault {
     ) -> Option<Self> {
         let f = |i: core::ffi::c_uint| f(i.into());
         let length: core::ffi::c_uint = length.try_into().unwrap();
-        Some({
-            #[sel4_cfg_match]
+        Some(sel4_cfg_wrap_match! {
             match label {
                 seL4_Fault_tag::seL4_Fault_UnknownSyscall => {
                     assert!(length == seL4_UnknownSyscall_Msg::seL4_UnknownSyscall_Length);

--- a/crates/sel4/sys/src/fault/arch/riscv.rs
+++ b/crates/sel4/sys/src/fault/arch/riscv.rs
@@ -10,7 +10,11 @@ use crate::c::*;
 use sel4_config::sel4_cfg_match;
 
 impl seL4_Fault {
-    pub(crate) fn arch_get_with(label: seL4_Word, length: seL4_Word, f: impl Fn(core::ffi::c_ulong) -> seL4_Word) -> Option<Self> {
+    pub(crate) fn arch_get_with(
+        label: seL4_Word,
+        length: seL4_Word,
+        f: impl Fn(core::ffi::c_ulong) -> seL4_Word,
+    ) -> Option<Self> {
         let f = |i: core::ffi::c_uint| f(i.into());
         let length: core::ffi::c_uint = length.try_into().unwrap();
         Some({
@@ -53,9 +57,7 @@ impl seL4_Fault {
                     }
                     .unsplay()
                 }
-                _ => {
-                    return None
-                }
+                _ => return None,
             }
         })
     }

--- a/crates/sel4/sys/src/fault/arch/x86_64.rs
+++ b/crates/sel4/sys/src/fault/arch/x86_64.rs
@@ -7,7 +7,7 @@
 use crate::bf::*;
 use crate::c::*;
 
-use sel4_config::sel4_cfg_match;
+use sel4_config::sel4_cfg_wrap_match;
 
 impl seL4_Fault {
     pub(crate) fn arch_get_with(
@@ -15,8 +15,7 @@ impl seL4_Fault {
         length: seL4_Word,
         f: impl Fn(core::ffi::c_ulong) -> seL4_Word,
     ) -> Option<Self> {
-        Some({
-            #[sel4_cfg_match]
+        Some(sel4_cfg_wrap_match! {
             match label {
                 seL4_Fault_tag::seL4_Fault_UnknownSyscall => {
                     assert!(length == seL4_UnknownSyscall_Msg::seL4_UnknownSyscall_Length);

--- a/crates/sel4/sys/src/fault/arch/x86_64.rs
+++ b/crates/sel4/sys/src/fault/arch/x86_64.rs
@@ -10,7 +10,11 @@ use crate::c::*;
 use sel4_config::sel4_cfg_match;
 
 impl seL4_Fault {
-    pub(crate) fn arch_get_with(label: seL4_Word, length: seL4_Word, f: impl Fn(core::ffi::c_ulong) -> seL4_Word) -> Option<Self> {
+    pub(crate) fn arch_get_with(
+        label: seL4_Word,
+        length: seL4_Word,
+        f: impl Fn(core::ffi::c_ulong) -> seL4_Word,
+    ) -> Option<Self> {
         Some({
             #[sel4_cfg_match]
             match label {
@@ -60,9 +64,7 @@ impl seL4_Fault {
                     }
                     .unsplay()
                 }
-                _ => {
-                    return None
-                }
+                _ => return None,
             }
         })
     }

--- a/crates/sel4/sys/src/lib.rs
+++ b/crates/sel4/sys/src/lib.rs
@@ -5,8 +5,6 @@
 //
 
 #![no_std]
-#![feature(proc_macro_hygiene)]
-#![feature(stmt_expr_attributes)]
 #![feature(thread_local)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/crates/sel4/sys/src/syscalls/helpers/arch/aarch32.rs
+++ b/crates/sel4/sys/src/syscalls/helpers/arch/aarch32.rs
@@ -9,8 +9,8 @@ use core::ffi::c_int;
 
 use sel4_config::sel4_cfg;
 
-use crate::{seL4_Word, seL4_MessageInfo};
 use super::sys_id_to_word;
+use crate::{seL4_MessageInfo, seL4_Word};
 
 // NOTE:
 // asm!() does not allow r6 to be used for input or output operands, because it's sometimes used by LLVM.
@@ -58,11 +58,7 @@ pub fn sys_reply(
     }
 }
 
-pub fn sys_send_null(
-    sys: c_int,
-    src: seL4_Word,
-    info_arg: seL4_MessageInfo,
-) {
+pub fn sys_send_null(sys: c_int, src: seL4_Word, info_arg: seL4_MessageInfo) {
     unsafe {
         asm!("swi 0",
             in("r7") sys_id_to_word(sys),
@@ -170,9 +166,7 @@ pub fn sys_nb_send_recv(
     (seL4_MessageInfo::from_word(out_info), out_badge)
 }
 
-pub fn sys_null(
-    sys: c_int,
-) {
+pub fn sys_null(sys: c_int) {
     unsafe {
         asm!("swi 0",
             in("r7") sys_id_to_word(sys),

--- a/crates/sel4/sys/src/syscalls/helpers/arch/aarch64.rs
+++ b/crates/sel4/sys/src/syscalls/helpers/arch/aarch64.rs
@@ -9,8 +9,8 @@ use core::ffi::c_int;
 
 use sel4_config::sel4_cfg;
 
-use crate::{seL4_Word, seL4_MessageInfo};
 use super::sys_id_to_word;
+use crate::{seL4_MessageInfo, seL4_Word};
 
 pub fn sys_send(
     sys: c_int,
@@ -55,11 +55,7 @@ pub fn sys_reply(
     }
 }
 
-pub fn sys_send_null(
-    sys: c_int,
-    src: seL4_Word,
-    info_arg: seL4_MessageInfo,
-) {
+pub fn sys_send_null(sys: c_int, src: seL4_Word, info_arg: seL4_MessageInfo) {
     unsafe {
         asm!("svc 0",
             in("x7") sys_id_to_word(sys),
@@ -152,9 +148,7 @@ pub fn sys_nb_send_recv(
     (seL4_MessageInfo::from_word(out_info), out_badge)
 }
 
-pub fn sys_null(
-    sys: c_int,
-) {
+pub fn sys_null(sys: c_int) {
     unsafe {
         asm!("svc 0",
             in("x7") sys_id_to_word(sys),

--- a/crates/sel4/sys/src/syscalls/helpers/arch/mod.rs
+++ b/crates/sel4/sys/src/syscalls/helpers/arch/mod.rs
@@ -26,6 +26,16 @@ sel4_cfg_if! {
     }
 }
 
+// HACK for rustfmt
+#[cfg(any())]
+mod aarch32;
+#[cfg(any())]
+mod aarch64;
+#[cfg(any())]
+mod riscv;
+#[cfg(any())]
+mod x86_64;
+
 pub use imp::*;
 
 fn sys_id_to_word(sys_id: c_int) -> seL4_Word {

--- a/crates/sel4/sys/src/syscalls/helpers/arch/riscv.rs
+++ b/crates/sel4/sys/src/syscalls/helpers/arch/riscv.rs
@@ -9,8 +9,8 @@ use core::ffi::c_int;
 
 use sel4_config::sel4_cfg;
 
-use crate::{seL4_Word, seL4_MessageInfo};
 use super::sys_id_to_word;
+use crate::{seL4_MessageInfo, seL4_Word};
 
 pub fn sys_send(
     sys: c_int,
@@ -55,11 +55,7 @@ pub fn sys_reply(
     }
 }
 
-pub fn sys_send_null(
-    sys: c_int,
-    src: seL4_Word,
-    info_arg: seL4_MessageInfo,
-) {
+pub fn sys_send_null(sys: c_int, src: seL4_Word, info_arg: seL4_MessageInfo) {
     unsafe {
         asm!("ecall",
             in("a7") sys_id_to_word(sys),
@@ -152,9 +148,7 @@ pub fn sys_nb_send_recv(
     (seL4_MessageInfo::from_word(out_info), out_badge)
 }
 
-pub fn sys_null(
-    sys: c_int,
-) {
+pub fn sys_null(sys: c_int) {
     unsafe {
         asm!("ecall",
             in("a7") sys_id_to_word(sys),

--- a/crates/sel4/sys/src/syscalls/helpers/arch/x86_64.rs
+++ b/crates/sel4/sys/src/syscalls/helpers/arch/x86_64.rs
@@ -9,8 +9,8 @@ use core::ffi::c_int;
 
 use sel4_config::sel4_cfg;
 
-use crate::{seL4_Word, seL4_MessageInfo};
 use super::sys_id_to_word;
+use crate::{seL4_MessageInfo, seL4_Word};
 
 #[sel4_cfg(not(SYSCALL))]
 compile_error!("unsupported configuration");
@@ -70,11 +70,7 @@ pub fn sys_reply(
     }
 }
 
-pub fn sys_send_null(
-    sys: c_int,
-    src: seL4_Word,
-    info_arg: seL4_MessageInfo,
-) {
+pub fn sys_send_null(sys: c_int, src: seL4_Word, info_arg: seL4_MessageInfo) {
     unsafe {
         asm!(
             "mov r14, rsp",
@@ -191,9 +187,7 @@ pub fn sys_nb_send_recv(
     (seL4_MessageInfo::from_word(out_info), out_badge)
 }
 
-pub fn sys_null(
-    sys: c_int,
-) {
+pub fn sys_null(sys: c_int) {
     unsafe {
         asm!(
             "mov r14, rsp",

--- a/hacking/unstable-feature-monitoring/wishlist/src/lib.rs
+++ b/hacking/unstable-feature-monitoring/wishlist/src/lib.rs
@@ -45,7 +45,7 @@
 // (See definitions of pointer::is_aligned(_to)?)
 #![feature(pointer_is_aligned)]
 
-// Without these, the more invasive sel4_cfg_if! must be used instead of #[sel4_cfg] on
-// expressions.
+// Without these, the more invasive sel4_cfg_if! and sel4_cfg_wrap_match! must be used instead of
+// #[sel4_cfg] and #[sel4_cfg_match] on expressions and non-inline module declarations.
 #![feature(proc_macro_hygiene)]
 #![feature(stmt_expr_attributes)]


### PR DESCRIPTION
Remove usage of the following unstable features:

```rust
#![feature(proc_macro_hygiene)]
#![feature(stmt_expr_attributes)]
```

As a consequence, we can no longer use the `sel4_config::*` attribute macros on statements of non-inline module declarations.

So, we replace `#![sel4_config::sel4_cfg]` with `sel4_config::sel4_cfg_if! {}` in the relevant cases, and add a new expression macro called `sel4_config::sel4_cfg_wrap_match! {}` to be used in place of `#[sel4_config::sel4_cfg_match]` until those unstable features are stabilized.

In the cases relevant to this PR, attribute macros are generally preferable over expression macros because the play more nicely with external tools like rustfmt, but, for now, we must make due with expression macros.