### PR TITLE
Remove usage unstable `never`-related features

### DIFF
--- a/crates/examples/microkit/banscii/pds/artist/src/main.rs
+++ b/crates/examples/microkit/banscii/pds/artist/src/main.rs
@@ -6,7 +6,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(never_type)]
 
 extern crate alloc;
 
@@ -16,7 +15,9 @@ use sel4_externally_shared::{
     access::{ReadOnly, ReadWrite},
     ExternallySharedRef, ExternallySharedRefExt,
 };
-use sel4_microkit::{memory_region_symbol, protection_domain, Channel, Handler, MessageInfo};
+use sel4_microkit::{
+    memory_region_symbol, protection_domain, Channel, Handler, Infallible, MessageInfo,
+};
 use sel4_microkit_message::MessageInfoExt as _;
 
 use banscii_artist_interface_types::*;
@@ -54,7 +55,7 @@ struct HandlerImpl {
 }
 
 impl Handler for HandlerImpl {
-    type Error = !;
+    type Error = Infallible;
 
     fn protected(
         &mut self,

--- a/crates/examples/microkit/banscii/pds/assistant/src/main.rs
+++ b/crates/examples/microkit/banscii/pds/assistant/src/main.rs
@@ -6,7 +6,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(never_type)]
 
 extern crate alloc;
 
@@ -21,7 +20,9 @@ use sel4_externally_shared::{
     access::{ReadOnly, ReadWrite},
     ExternallySharedRef, ExternallySharedRefExt,
 };
-use sel4_microkit::{memory_region_symbol, protection_domain, Channel, Handler, MessageInfo};
+use sel4_microkit::{
+    memory_region_symbol, protection_domain, Channel, Handler, Infallible, MessageInfo,
+};
 use sel4_microkit_message::MessageInfoExt as _;
 
 use banscii_artist_interface_types as artist;
@@ -63,7 +64,7 @@ struct HandlerImpl {
 }
 
 impl Handler for HandlerImpl {
-    type Error = !;
+    type Error = Infallible;
 
     fn notified(&mut self, channel: Channel) -> Result<(), Self::Error> {
         match channel {

--- a/crates/examples/microkit/banscii/pds/pl011-driver/src/main.rs
+++ b/crates/examples/microkit/banscii/pds/pl011-driver/src/main.rs
@@ -6,11 +6,12 @@
 
 #![no_std]
 #![no_main]
-#![feature(never_type)]
 
 use heapless::Deque;
 
-use sel4_microkit::{memory_region_symbol, protection_domain, Channel, Handler, MessageInfo};
+use sel4_microkit::{
+    memory_region_symbol, protection_domain, Channel, Handler, Infallible, MessageInfo,
+};
 use sel4_microkit_message::MessageInfoExt as _;
 
 use banscii_pl011_driver_core::Driver;
@@ -37,7 +38,7 @@ struct HandlerImpl {
 }
 
 impl Handler for HandlerImpl {
-    type Error = !;
+    type Error = Infallible;
 
     fn notified(&mut self, channel: Channel) -> Result<(), Self::Error> {
         match channel {

--- a/crates/examples/microkit/hello/pds/hello/src/main.rs
+++ b/crates/examples/microkit/hello/pds/hello/src/main.rs
@@ -6,9 +6,8 @@
 
 #![no_std]
 #![no_main]
-#![feature(never_type)]
 
-use sel4_microkit::{debug_println, protection_domain, Handler};
+use sel4_microkit::{debug_println, protection_domain, Handler, Infallible};
 
 #[protection_domain]
 fn init() -> HandlerImpl {
@@ -19,5 +18,5 @@ fn init() -> HandlerImpl {
 struct HandlerImpl;
 
 impl Handler for HandlerImpl {
-    type Error = !;
+    type Error = Infallible;
 }

--- a/crates/examples/microkit/http-server/pds/pl031-driver/src/main.rs
+++ b/crates/examples/microkit/http-server/pds/pl031-driver/src/main.rs
@@ -6,9 +6,10 @@
 
 #![no_std]
 #![no_main]
-#![feature(never_type)]
 
-use sel4_microkit::{memory_region_symbol, protection_domain, Channel, Handler, MessageInfo};
+use sel4_microkit::{
+    memory_region_symbol, protection_domain, Channel, Handler, Infallible, MessageInfo,
+};
 use sel4_microkit_message::MessageInfoExt as _;
 
 use microkit_http_server_example_pl031_driver_core::Driver;
@@ -29,7 +30,7 @@ struct HandlerImpl {
 }
 
 impl Handler for HandlerImpl {
-    type Error = !;
+    type Error = Infallible;
 
     fn protected(
         &mut self,

--- a/crates/examples/microkit/http-server/pds/server/src/main.rs
+++ b/crates/examples/microkit/http-server/pds/server/src/main.rs
@@ -6,7 +6,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(never_type)]
 
 extern crate alloc;
 

--- a/crates/examples/microkit/http-server/pds/sp804-driver/src/main.rs
+++ b/crates/examples/microkit/http-server/pds/sp804-driver/src/main.rs
@@ -6,11 +6,12 @@
 
 #![no_std]
 #![no_main]
-#![feature(never_type)]
 
 use core::time::Duration;
 
-use sel4_microkit::{memory_region_symbol, protection_domain, Channel, Handler, MessageInfo};
+use sel4_microkit::{
+    memory_region_symbol, protection_domain, Channel, Handler, Infallible, MessageInfo,
+};
 use sel4_microkit_message::MessageInfoExt as _;
 
 use microkit_http_server_example_sp804_driver_core::Driver;
@@ -36,7 +37,7 @@ struct HandlerImpl {
 }
 
 impl Handler for HandlerImpl {
-    type Error = !;
+    type Error = Infallible;
 
     fn notified(&mut self, channel: Channel) -> Result<(), Self::Error> {
         match channel {

--- a/crates/examples/microkit/http-server/pds/virtio-blk-driver/src/main.rs
+++ b/crates/examples/microkit/http-server/pds/virtio-blk-driver/src/main.rs
@@ -6,7 +6,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(never_type)]
 
 extern crate alloc;
 
@@ -24,7 +23,9 @@ use virtio_drivers::{
 };
 
 use sel4_externally_shared::{ExternallySharedRef, ExternallySharedRefExt};
-use sel4_microkit::{memory_region_symbol, protection_domain, var, Channel, Handler, MessageInfo};
+use sel4_microkit::{
+    memory_region_symbol, protection_domain, var, Channel, Handler, Infallible, MessageInfo,
+};
 use sel4_microkit_message::MessageInfoExt as _;
 use sel4_shared_ring_buffer::{roles::Use, RingBuffers};
 use sel4_shared_ring_buffer_block_io_types::{
@@ -102,7 +103,7 @@ struct PendingEntry {
 }
 
 impl Handler for HandlerImpl {
-    type Error = !;
+    type Error = Infallible;
 
     fn notified(&mut self, channel: Channel) -> Result<(), Self::Error> {
         match channel {

--- a/crates/examples/microkit/http-server/pds/virtio-net-driver/src/main.rs
+++ b/crates/examples/microkit/http-server/pds/virtio-net-driver/src/main.rs
@@ -6,7 +6,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(never_type)]
 
 use core::ptr::NonNull;
 
@@ -19,7 +18,9 @@ use virtio_drivers::{
 };
 
 use sel4_externally_shared::{ExternallySharedRef, ExternallySharedRefExt};
-use sel4_microkit::{memory_region_symbol, protection_domain, var, Channel, Handler, MessageInfo};
+use sel4_microkit::{
+    memory_region_symbol, protection_domain, var, Channel, Handler, Infallible, MessageInfo,
+};
 use sel4_microkit_message::MessageInfoExt as _;
 use sel4_shared_ring_buffer::{roles::Use, RingBuffers};
 
@@ -95,7 +96,7 @@ struct HandlerImpl {
 }
 
 impl Handler for HandlerImpl {
-    type Error = !;
+    type Error = Infallible;
 
     fn notified(&mut self, channel: Channel) -> Result<(), Self::Error> {
         match channel {

--- a/crates/examples/root-task/example-root-task-without-runtime/src/main.rs
+++ b/crates/examples/root-task/example-root-task-without-runtime/src/main.rs
@@ -7,13 +7,11 @@
 #![no_std]
 #![no_main]
 #![feature(core_intrinsics)]
-#![feature(never_type)]
-#![feature(unwrap_infallible)]
 #![allow(internal_features)]
 
 use core::arch::global_asm;
 
-fn main(bootinfo: &sel4::BootInfo) -> sel4::Result<!> {
+fn main(bootinfo: &sel4::BootInfo) -> sel4::Result<Never> {
     sel4::debug_println!("Hello, World!");
 
     let mut ipc_buffer = unsafe { bootinfo.ipc_buffer() };
@@ -78,6 +76,8 @@ fn main(bootinfo: &sel4::BootInfo) -> sel4::Result<!> {
 }
 
 // minimal ad-hoc runtime
+
+enum Never {}
 
 mod stack {
     use core::cell::UnsafeCell;
@@ -203,8 +203,10 @@ cfg_if::cfg_if! {
 #[no_mangle]
 unsafe extern "C" fn __rust_entry(bootinfo: *const sel4::sys::seL4_BootInfo) -> ! {
     let bootinfo = sel4::BootInfo::from_ptr(bootinfo);
-    let err = main(&bootinfo).into_err();
-    panic!("Error: {}", err)
+    match main(&bootinfo) {
+        Ok(absurdity) => match absurdity {},
+        Err(err) => panic!("Error: {}", err),
+    }
 }
 
 #[panic_handler]

--- a/crates/examples/root-task/example-root-task/src/main.rs
+++ b/crates/examples/root-task/example-root-task/src/main.rs
@@ -6,12 +6,11 @@
 
 #![no_std]
 #![no_main]
-#![feature(never_type)]
 
-use sel4_root_task::root_task;
+use sel4_root_task::{root_task, Never};
 
 #[root_task]
-fn main(bootinfo: &sel4::BootInfo) -> sel4::Result<!> {
+fn main(bootinfo: &sel4::BootInfo) -> sel4::Result<Never> {
     sel4::debug_println!("Hello, World!");
 
     let blueprint = sel4::ObjectBlueprint::Notification;

--- a/crates/examples/root-task/hello/src/main.rs
+++ b/crates/examples/root-task/hello/src/main.rs
@@ -6,7 +6,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(never_type)]
 
 use sel4_root_task::root_task;
 

--- a/crates/private/support/sel4-simple-task/runtime/config/cli/src/bin/sel4-simple-task-serialize-runtime-config.rs
+++ b/crates/private/support/sel4-simple-task/runtime/config/cli/src/bin/sel4-simple-task-serialize-runtime-config.rs
@@ -4,9 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
-#![feature(never_type)]
-#![feature(unwrap_infallible)]
-
+use std::convert::Infallible;
 use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;
@@ -18,8 +16,8 @@ fn main() -> Result<(), std::io::Error> {
     let config = config.traverse(fs::read)?;
     let packed = config.pack();
     let unpacked_for_sanity_check = RuntimeConfigForPacking::unpack(&RuntimeConfig::new(&packed))
-        .traverse(|bytes| Ok::<_, !>(bytes.to_vec()))
-        .into_ok();
+        .traverse(|bytes| Ok::<_, Infallible>(bytes.to_vec()))
+        .unwrap_or_else(|absurdity| match absurdity {});
     assert_eq!(config, unpacked_for_sanity_check);
     io::stdout().write_all(&packed)?;
     Ok(())

--- a/crates/private/tests/microkit/passive-server-with-deferred-action/pds/client/src/bin/client.rs
+++ b/crates/private/tests/microkit/passive-server-with-deferred-action/pds/client/src/bin/client.rs
@@ -6,9 +6,8 @@
 
 #![no_std]
 #![no_main]
-#![feature(never_type)]
 
-use sel4_microkit::{debug_println, protection_domain, Channel, Handler};
+use sel4_microkit::{debug_println, protection_domain, Channel, Handler, Infallible};
 
 const SERVER: Channel = Channel::new(0);
 
@@ -21,7 +20,7 @@ fn init() -> impl Handler {
 struct HandlerImpl {}
 
 impl Handler for HandlerImpl {
-    type Error = !;
+    type Error = Infallible;
 
     fn notified(&mut self, _channel: Channel) -> Result<(), Self::Error> {
         debug_println!("TEST_PASS");

--- a/crates/private/tests/microkit/passive-server-with-deferred-action/pds/server/src/bin/server.rs
+++ b/crates/private/tests/microkit/passive-server-with-deferred-action/pds/server/src/bin/server.rs
@@ -6,9 +6,10 @@
 
 #![no_std]
 #![no_main]
-#![feature(never_type)]
 
-use sel4_microkit::{protection_domain, Channel, DeferredAction, DeferredActionSlot, Handler};
+use sel4_microkit::{
+    protection_domain, Channel, DeferredAction, DeferredActionSlot, Handler, Infallible,
+};
 
 const CLIENT: Channel = Channel::new(0);
 
@@ -24,7 +25,7 @@ struct HandlerImpl {
 }
 
 impl Handler for HandlerImpl {
-    type Error = !;
+    type Error = Infallible;
 
     fn notified(&mut self, _channel: Channel) -> Result<(), Self::Error> {
         self.deferred_action.defer(CLIENT.defer_notify()).unwrap();

--- a/crates/sel4-async/block-io/fat/src/block_io_wrapper.rs
+++ b/crates/sel4-async/block-io/fat/src/block_io_wrapper.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
+use core::convert::Infallible;
 use core::marker::PhantomData;
 
 use futures::future;
@@ -32,7 +33,7 @@ impl<T, A> BlockIOWrapper<T, A> {
 impl<T: BlockIO<A, BlockSize = constant_block_sizes::BlockSize512>, A: Access> fat::BlockDevice
     for BlockIOWrapper<T, A>
 {
-    type Error = !;
+    type Error = Infallible;
 
     async fn read(
         &self,

--- a/crates/sel4-async/block-io/fat/src/lib.rs
+++ b/crates/sel4-async/block-io/fat/src/lib.rs
@@ -5,7 +5,6 @@
 //
 
 #![no_std]
-#![feature(never_type)]
 
 pub use embedded_fat::*;
 

--- a/crates/sel4-async/block-io/src/access.rs
+++ b/crates/sel4-async/block-io/src/access.rs
@@ -9,6 +9,15 @@ pub trait Access: AccessSealed {
     type WriteWitness: Witness;
 }
 
+#[derive(Copy, Clone)]
+pub enum Absurdity {}
+
+impl Absurdity {
+    pub(crate) fn absurd<T>(self) -> T {
+        match self {}
+    }
+}
+
 pub trait Witness: Sized + Copy + Unpin {
     const TRY_WITNESS: Option<Self>;
 }
@@ -17,7 +26,7 @@ impl Witness for () {
     const TRY_WITNESS: Option<Self> = Some(());
 }
 
-impl Witness for ! {
+impl Witness for Absurdity {
     const TRY_WITNESS: Option<Self> = None;
 }
 
@@ -45,7 +54,7 @@ pub enum ReadOnly {}
 
 impl Access for ReadOnly {
     type ReadWitness = ();
-    type WriteWitness = !;
+    type WriteWitness = Absurdity;
 }
 
 impl ReadAccess for ReadOnly {
@@ -55,7 +64,7 @@ impl ReadAccess for ReadOnly {
 pub enum WriteOnly {}
 
 impl Access for WriteOnly {
-    type ReadWitness = !;
+    type ReadWitness = Absurdity;
     type WriteWitness = ();
 }
 

--- a/crates/sel4-async/block-io/src/lib.rs
+++ b/crates/sel4-async/block-io/src/lib.rs
@@ -5,12 +5,12 @@
 //
 
 #![no_std]
-#![feature(never_type)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
 use core::cell::RefCell;
+use core::convert::Infallible;
 use core::fmt;
 use core::ops::Range;
 
@@ -459,7 +459,7 @@ impl<T> SliceByteIO<T> {
 }
 
 impl<T: AsRef<[u8]>> ByteIOLayout for SliceByteIO<T> {
-    type Error = !;
+    type Error = Infallible;
 
     fn size(&self) -> u64 {
         self.inner().as_ref().len().try_into().unwrap()
@@ -477,14 +477,14 @@ impl<T: AsRef<[u8]>> ByteIO<ReadOnly> for SliceByteIO<T> {
             Operation::Read { buf, .. } => {
                 buf.copy_from_slice(&self.inner().as_ref()[offset..][..buf.len()]);
             }
-            Operation::Write { witness, .. } => witness,
+            Operation::Write { witness, .. } => witness.absurd(),
         }
         Ok(())
     }
 }
 
 impl<T: AsRef<[u8]> + AsMut<[u8]>> ByteIOLayout for RefCell<SliceByteIO<T>> {
-    type Error = !;
+    type Error = Infallible;
 
     fn size(&self) -> u64 {
         self.borrow().size()

--- a/crates/sel4-async/block-io/src/operation.rs
+++ b/crates/sel4-async/block-io/src/operation.rs
@@ -174,7 +174,7 @@ impl<'a> Operation<'a, ReadOnly> {
     pub fn as_read(&'a mut self) -> &'a mut [u8] {
         match self {
             Self::Read { buf, .. } => buf,
-            Self::Write { witness, .. } => *witness,
+            Self::Write { witness, .. } => witness.absurd(),
         }
     }
 }
@@ -183,7 +183,7 @@ impl<'a> Operation<'a, WriteOnly> {
     #[allow(clippy::explicit_auto_deref)]
     pub fn as_write(&'a self) -> &'a [u8] {
         match self {
-            Self::Read { witness, .. } => *witness,
+            Self::Read { witness, .. } => witness.absurd(),
             Self::Write { buf, .. } => buf,
         }
     }

--- a/crates/sel4-backtrace/simple/src/lib.rs
+++ b/crates/sel4-backtrace/simple/src/lib.rs
@@ -5,8 +5,8 @@
 //
 
 #![no_std]
-#![feature(never_type)]
-#![feature(unwrap_infallible)]
+
+use core::convert::Infallible;
 
 use sel4_backtrace::{BacktraceSendWithToken, BacktraceSendWithoutToken};
 use sel4_panicking_env::{debug_print, debug_println};
@@ -28,7 +28,10 @@ impl SimpleBacktracing {
     pub fn collect_and_send(&self) {
         debug_println!("collecting and sending stack backtrace");
         debug_print!("    ");
-        let r = self.0.collect_and_send().into_ok();
+        let r = self
+            .0
+            .collect_and_send()
+            .unwrap_or_else(|absurdity| match absurdity {});
         debug_println!();
         debug_println!();
         if r.is_err() {
@@ -46,7 +49,10 @@ impl SimpleBacktracing {
     pub fn send(&self, bt: &Backtrace<Option<&'static str>>) {
         debug_println!("sending stack backtrace");
         debug_print!("    ");
-        let r = self.0.send(bt).into_ok();
+        let r = self
+            .0
+            .send(bt)
+            .unwrap_or_else(|absurdity| match absurdity {});
         debug_println!();
         debug_println!();
         if r.is_err() {
@@ -67,7 +73,7 @@ impl SimpleBacktraceSend {
 
 impl BacktraceSendWithoutToken for SimpleBacktraceSend {
     type Image = Option<&'static str>;
-    type TxError = !;
+    type TxError = Infallible;
 
     fn image(&self) -> Self::Image {
         self.image

--- a/crates/sel4-backtrace/src/lib.rs
+++ b/crates/sel4-backtrace/src/lib.rs
@@ -5,7 +5,8 @@
 //
 
 #![no_std]
-#![feature(never_type)]
+
+use core::convert::Infallible;
 
 #[cfg(feature = "postcard")]
 use serde::Serialize;
@@ -67,7 +68,7 @@ cfg_if::cfg_if! {
             let mut builder = Backtrace::builder(image);
             let error = collect_with(|entry| {
                 builder.append(entry);
-                Ok::<_, !>(())
+                Ok::<_, Infallible>(())
             });
             builder.finalize(error)
         }
@@ -120,7 +121,7 @@ cfg_if::cfg_if! {
         impl<T: BacktraceSendWithoutToken> BacktraceSendWithToken for T {
             type Image = <Self as BacktraceSendWithoutToken>::Image;
             type Token = ();
-            type ControlError = !;
+            type ControlError = Infallible;
             type TxError = <Self as BacktraceSendWithoutToken>::TxError;
 
             fn image(&self) -> Self::Image {

--- a/crates/sel4-backtrace/types/src/lib.rs
+++ b/crates/sel4-backtrace/types/src/lib.rs
@@ -5,7 +5,6 @@
 //
 
 #![no_std]
-#![feature(never_type)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/crates/sel4-backtrace/types/src/with_alloc.rs
+++ b/crates/sel4-backtrace/types/src/with_alloc.rs
@@ -6,6 +6,7 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
+use core::convert::Infallible;
 
 #[cfg(feature = "postcard")]
 use core::fmt;
@@ -29,7 +30,7 @@ impl<T: Serialize> Backtrace<T> {
         let mut acc = vec![];
         let mut send_byte = |b| {
             acc.push(b);
-            Ok::<_, !>(())
+            Ok::<_, Infallible>(())
         };
         self.preamble.send(&mut send_byte)?;
         for entry in &self.entries {

--- a/crates/sel4-capdl-initializer/add-spec/src/main.rs
+++ b/crates/sel4-capdl-initializer/add-spec/src/main.rs
@@ -4,9 +4,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
-#![feature(never_type)]
-#![feature(unwrap_infallible)]
-
 use std::fs;
 
 use anyhow::Result;

--- a/crates/sel4-capdl-initializer/embed-spec/src/lib.rs
+++ b/crates/sel4-capdl-initializer/embed-spec/src/lib.rs
@@ -4,9 +4,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
-#![feature(never_type)]
-#![feature(unwrap_infallible)]
-
 // TODO(nspin)
 // In a few cases, we use a local const declaration to appease the borrow checker.
 // Using an exposed constructor of `Indirect` would be one way around this.
@@ -323,7 +320,7 @@ impl<'a> Embedding<'a> {
         let mut embedded_frame_count = 0usize;
         let spec = self
             .spec()
-            .traverse_data::<Ident, !>(|data| {
+            .traverse_data(|data| {
                 let id = hex::encode_upper(format!(
                     "{},{},{}",
                     data.file_range().start,
@@ -338,10 +335,9 @@ impl<'a> Embedding<'a> {
                     });
                     self.pack_fill(self.fill_map.get(data))
                 });
-                Ok(ident)
+                ident
             })
-            .into_ok()
-            .traverse_embedded_frames::<Ident, !>(|fill| {
+            .traverse_embedded_frames(|fill| {
                 let ident = format_ident!("FRAME_{}", embedded_frame_count);
                 let fname = format!("frame.{}.bin", embedded_frame_count);
                 file_inclusion_toks.extend(quote! {
@@ -351,9 +347,8 @@ impl<'a> Embedding<'a> {
                 });
                 files_for_inclusion.insert(fname, self.fill_map.get_frame(self.granule_size(), fill));
                 embedded_frame_count += 1;
-                Ok(ident)
-            })
-            .into_ok();
+                ident
+            });
 
         let types_mod = self.types_mod();
         let name_type = self.name_type(true);

--- a/crates/sel4-capdl-initializer/src/main.rs
+++ b/crates/sel4-capdl-initializer/src/main.rs
@@ -49,7 +49,6 @@ fn main(bootinfo: &BootInfo) -> ! {
         &spec_with_sources,
         &mut buffers,
     )
-    .unwrap_or_else(|err| panic!("Error: {}", err))
 }
 
 #[no_mangle]

--- a/crates/sel4-capdl-initializer/types/src/frame_init.rs
+++ b/crates/sel4-capdl-initializer/types/src/frame_init.rs
@@ -51,17 +51,17 @@ impl<'a, D, M> FrameInit<'a, D, M> {
     }
 }
 
-impl<'a, D> FrameInit<'a, D, !> {
+impl<'a, D> FrameInit<'a, D, NeverEmbedded> {
     #[allow(clippy::explicit_auto_deref)]
     pub const fn as_fill_infallible(&self) -> &Fill<'a, D> {
         match self {
             Self::Fill(fill) => fill,
-            Self::Embedded(never) => *never,
+            Self::Embedded(absurdity) => match *absurdity {},
         }
     }
 }
 
-impl<'a, D> object::Frame<'a, D, !> {
+impl<'a, D> object::Frame<'a, D, NeverEmbedded> {
     pub fn can_embed(&self, granule_size_bits: usize, is_root: bool) -> bool {
         is_root
             && self.paddr.is_none()
@@ -70,6 +70,11 @@ impl<'a, D> object::Frame<'a, D, !> {
             && !self.init.as_fill_infallible().depends_on_bootinfo()
     }
 }
+
+// // //
+
+#[derive(Copy, Clone)]
+pub enum NeverEmbedded {}
 
 // // //
 

--- a/crates/sel4-capdl-initializer/types/src/lib.rs
+++ b/crates/sel4-capdl-initializer/types/src/lib.rs
@@ -5,8 +5,6 @@
 //
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(never_type)]
-#![feature(unwrap_infallible)]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
@@ -36,7 +34,7 @@ pub use footprint::Footprint;
 pub use frame_init::{
     BytesContent, Content, EmbeddedFrame, Fill, FillEntry, FillEntryContent,
     FillEntryContentBootInfo, FillEntryContentBootInfoId, FrameInit, GetEmbeddedFrame,
-    IndirectBytesContent, IndirectEmbeddedFrame, SelfContainedContent,
+    IndirectBytesContent, IndirectEmbeddedFrame, NeverEmbedded, SelfContainedContent,
     SelfContainedGetEmbeddedFrame,
 };
 pub use indirect::Indirect;

--- a/crates/sel4-capdl-initializer/with-embedded-spec/build-env/src/lib.rs
+++ b/crates/sel4-capdl-initializer/with-embedded-spec/build-env/src/lib.rs
@@ -4,8 +4,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
-#![feature(never_type)]
-
 use std::borrow::Cow;
 use std::env;
 use std::fs;

--- a/crates/sel4-capdl-initializer/with-embedded-spec/src/main.rs
+++ b/crates/sel4-capdl-initializer/with-embedded-spec/src/main.rs
@@ -42,7 +42,6 @@ fn main(bootinfo: &BootInfo) -> ! {
     Initializer::initialize(bootinfo, user_image_bounds(), &spec_with_sources, unsafe {
         &mut BUFFERS
     })
-    .unwrap_or_else(|err| panic!("Error: {}", err))
 }
 
 extern "C" {

--- a/crates/sel4-hal-adapters/src/lib.rs
+++ b/crates/sel4-hal-adapters/src/lib.rs
@@ -6,7 +6,6 @@
 //
 
 #![no_std]
-#![feature(never_type)]
 
 #[cfg(feature = "smoltcp-hal")]
 pub mod smoltcp;

--- a/crates/sel4-hal-adapters/src/smoltcp/phy/handler.rs
+++ b/crates/sel4-hal-adapters/src/smoltcp/phy/handler.rs
@@ -15,7 +15,7 @@ use smoltcp::{
 use serde::{Deserialize, Serialize};
 
 use sel4_externally_shared::ExternallySharedRef;
-use sel4_microkit::{Channel, Handler, MessageInfo};
+use sel4_microkit::{Channel, Handler, Infallible, MessageInfo};
 use sel4_microkit_message::MessageInfoExt as _;
 use sel4_shared_ring_buffer::{roles::Use, RingBuffers};
 
@@ -44,8 +44,8 @@ pub struct PhyDeviceHandler<Device> {
     dev: Device,
     client_region: ExternallySharedRef<'static, [u8]>,
     client_region_paddr: usize,
-    rx_ring_buffers: RingBuffers<'static, Use, fn() -> Result<(), !>>,
-    tx_ring_buffers: RingBuffers<'static, Use, fn() -> Result<(), !>>,
+    rx_ring_buffers: RingBuffers<'static, Use, fn() -> Result<(), Infallible>>,
+    tx_ring_buffers: RingBuffers<'static, Use, fn() -> Result<(), Infallible>>,
     device_channel: Channel,
     client_channel: Channel,
 }
@@ -55,8 +55,8 @@ impl<Device> PhyDeviceHandler<Device> {
         dev: Device,
         client_region: ExternallySharedRef<'static, [u8]>,
         client_region_paddr: usize,
-        rx_ring_buffers: RingBuffers<'static, Use, fn() -> Result<(), !>>,
-        tx_ring_buffers: RingBuffers<'static, Use, fn() -> Result<(), !>>,
+        rx_ring_buffers: RingBuffers<'static, Use, fn() -> Result<(), Infallible>>,
+        tx_ring_buffers: RingBuffers<'static, Use, fn() -> Result<(), Infallible>>,
         device_channel: Channel,
         client_channel: Channel,
     ) -> Self {
@@ -75,7 +75,7 @@ impl<Device> PhyDeviceHandler<Device> {
 }
 
 impl<Device: phy::Device + IrqAck + HasMac> Handler for PhyDeviceHandler<Device> {
-    type Error = !;
+    type Error = Infallible;
 
     fn notified(&mut self, channel: Channel) -> Result<(), Self::Error> {
         if channel == self.device_channel || channel == self.client_channel {

--- a/crates/sel4-microkit/message/src/lib.rs
+++ b/crates/sel4-microkit/message/src/lib.rs
@@ -5,7 +5,6 @@
 //
 
 #![no_std]
-#![feature(unwrap_infallible)]
 
 use core::fmt;
 use core::mem;
@@ -35,7 +34,7 @@ pub trait MessageInfoExt: Sized {
     fn send_unspecified_error() -> Self;
 
     fn send_empty() -> Self {
-        Self::send(EmptyMessage).into_ok()
+        Self::send(EmptyMessage).unwrap_or_else(|absurdity| match absurdity {})
     }
 
     fn recv_empty(self) -> Result<(), MessageRecvErrorFor<EmptyMessage>> {

--- a/crates/sel4-microkit/message/types/src/lib.rs
+++ b/crates/sel4-microkit/message/types/src/lib.rs
@@ -5,8 +5,8 @@
 //
 
 #![no_std]
-#![feature(never_type)]
 
+use core::convert::Infallible;
 use core::fmt;
 use core::mem;
 
@@ -91,7 +91,7 @@ pub enum RecvFromBytesError {
 pub struct EmptyMessageValue;
 
 impl MessageValueSend for EmptyMessageValue {
-    type Error = !;
+    type Error = Infallible;
 
     fn write_message_value(self, _buf: &mut [u8]) -> Result<usize, Self::Error> {
         Ok(0)
@@ -99,7 +99,7 @@ impl MessageValueSend for EmptyMessageValue {
 }
 
 impl MessageValueRecv for EmptyMessageValue {
-    type Error = !;
+    type Error = Infallible;
 
     fn read_message_value(_buf: &[u8]) -> Result<Self, Self::Error> {
         Ok(Self)
@@ -114,7 +114,7 @@ pub struct EmptyMessage;
 impl MessageSend for EmptyMessage {
     type Label = DefaultMessageLabel;
 
-    type Error = !;
+    type Error = Infallible;
 
     fn write_message(self, buf: &mut [u8]) -> Result<(Self::Label, usize), Self::Error> {
         TriviallyLabeled(EmptyMessageValue).write_message(buf)
@@ -124,7 +124,7 @@ impl MessageSend for EmptyMessage {
 impl MessageRecv for EmptyMessage {
     type Label = DefaultMessageLabel;
 
-    type Error = !;
+    type Error = Infallible;
 
     fn read_message(label: Self::Label, buf: &[u8]) -> Result<Self, Self::Error> {
         TriviallyLabeled::<EmptyMessageValue>::read_message(label, buf).map(|_| Self)

--- a/crates/sel4-microkit/src/entry.rs
+++ b/crates/sel4-microkit/src/entry.rs
@@ -63,7 +63,11 @@ macro_rules! declare_init {
 
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn run_main<T: Handler>(init: impl FnOnce() -> T) {
-    match catch_unwind(|| run_handler(init()).into_err()) {
+    let result = catch_unwind(|| match run_handler(init()) {
+        Ok(absurdity) => match absurdity {},
+        Err(err) => err,
+    });
+    match result {
         Ok(err) => abort!("main thread terminated with error: {err}"),
         Err(_) => abort!("main thread panicked"),
     }

--- a/crates/sel4-microkit/src/handler.rs
+++ b/crates/sel4-microkit/src/handler.rs
@@ -6,6 +6,8 @@
 
 use core::fmt;
 
+pub use core::convert::Infallible;
+
 use crate::cspace::{
     Channel, DeferredAction, PreparedDeferredAction, INPUT_CAP, MONITOR_EP_CAP, REPLY_CAP,
 };
@@ -47,7 +49,9 @@ pub trait Handler {
     }
 }
 
-pub(crate) fn run_handler<T: Handler>(mut handler: T) -> Result<!, T::Error> {
+pub(crate) enum Never {}
+
+pub(crate) fn run_handler<T: Handler>(mut handler: T) -> Result<Never, T::Error> {
     let mut reply_tag: Option<MessageInfo> = None;
 
     let mut prepared_deferred_action: Option<PreparedDeferredAction> = if pd_is_passive() {
@@ -111,5 +115,5 @@ impl NullHandler {
 }
 
 impl Handler for NullHandler {
-    type Error = !;
+    type Error = Infallible;
 }

--- a/crates/sel4-microkit/src/lib.rs
+++ b/crates/sel4-microkit/src/lib.rs
@@ -6,8 +6,6 @@
 
 #![no_std]
 #![feature(cfg_target_thread_local)]
-#![feature(never_type)]
-#![feature(unwrap_infallible)]
 #![feature(used_with_arg)]
 
 //! A foundation for pure-Rust [seL4 Microkit](https://github.com/seL4/microkit) protection domains.
@@ -55,7 +53,7 @@ pub use cspace::{
     Channel, DeferredAction, DeferredActionInterface, DeferredActionSlot, IrqAckError,
 };
 pub use env::{pd_is_passive, pd_name};
-pub use handler::{Handler, NullHandler};
+pub use handler::{Handler, Infallible, NullHandler};
 pub use memory_region::{cast_memory_region_checked, cast_memory_region_to_slice_checked};
 pub use message::{
     get_mr, set_mr, with_msg_bytes, with_msg_bytes_mut, with_msg_regs, with_msg_regs_mut,

--- a/crates/sel4-root-task/src/lib.rs
+++ b/crates/sel4-root-task/src/lib.rs
@@ -7,7 +7,6 @@
 #![no_std]
 #![feature(cfg_target_thread_local)]
 #![feature(never_type)]
-#![feature(unwrap_infallible)]
 
 use core::ffi::c_char;
 use core::fmt;
@@ -23,7 +22,7 @@ pub use sel4_panicking as panicking;
 
 mod termination;
 
-use termination::Termination;
+pub use termination::{Never, Termination};
 
 #[cfg(target_thread_local)]
 #[no_mangle]

--- a/crates/sel4-root-task/src/termination.rs
+++ b/crates/sel4-root-task/src/termination.rs
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
+use core::fmt;
+
 pub trait Termination {
     type Error;
 
@@ -18,10 +20,42 @@ impl Termination for ! {
     }
 }
 
+impl Termination for Never {
+    type Error = Never;
+
+    fn report(self) -> Self::Error {
+        self
+    }
+}
+
 impl<E> Termination for Result<!, E> {
     type Error = E;
 
     fn report(self) -> Self::Error {
-        self.into_err()
+        match self {
+            Ok(absurdity) => match absurdity {},
+            Err(err) => err,
+        }
+    }
+}
+
+impl<E> Termination for Result<Never, E> {
+    type Error = E;
+
+    fn report(self) -> Self::Error {
+        match self {
+            Ok(absurdity) => match absurdity {},
+            Err(err) => err,
+        }
+    }
+}
+
+// NOTE(rustc_wishlist) remove once #![never_type] is stabilized
+#[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub enum Never {}
+
+impl fmt::Display for Never {
+    fn fmt(&self, _f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {}
     }
 }

--- a/crates/sel4-shared-ring-buffer/smoltcp/src/lib.rs
+++ b/crates/sel4-shared-ring-buffer/smoltcp/src/lib.rs
@@ -5,7 +5,6 @@
 //
 
 #![no_std]
-#![feature(never_type)]
 
 extern crate alloc;
 

--- a/hacking/unstable-feature-monitoring/wishlist/src/lib.rs
+++ b/hacking/unstable-feature-monitoring/wishlist/src/lib.rs
@@ -49,3 +49,6 @@
 // #[sel4_cfg] and #[sel4_cfg_match] on expressions and non-inline module declarations.
 #![feature(proc_macro_hygiene)]
 #![feature(stmt_expr_attributes)]
+
+#![feature(never_type)]
+#![feature(unwrap_infallible)]


### PR DESCRIPTION
Remove usage of the following unstable features:

```rust
#![feature(never_type)]
#![feature(unwrap_infallible)]
```
