### PR TITLE
Improve core runtime crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,7 +2232,6 @@ name = "sel4-initialize-tls-on-stack"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
- "sel4",
 ]
 
 [[package]]
@@ -2454,8 +2453,10 @@ name = "sel4-runtime-common"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
+ "sel4",
  "sel4-dlmalloc",
  "sel4-initialize-tls-on-stack",
+ "sel4-panicking-env",
  "sel4-sync",
  "unwinding",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,9 +936,9 @@ checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1078,7 +1078,6 @@ dependencies = [
  "sel4-shared-ring-buffer-block-io-types",
  "sel4-shared-ring-buffer-bookkeeping",
  "sel4-shared-ring-buffer-smoltcp",
- "sel4-sync",
  "smoltcp",
 ]
 
@@ -1146,7 +1145,6 @@ dependencies = [
  "sel4-microkit-message",
  "sel4-shared-ring-buffer",
  "sel4-shared-ring-buffer-block-io-types",
- "sel4-sync",
  "virtio-drivers",
 ]
 
@@ -1184,7 +1182,6 @@ dependencies = [
  "sel4-microkit",
  "sel4-microkit-message",
  "sel4-shared-ring-buffer",
- "sel4-sync",
  "virtio-drivers",
 ]
 
@@ -2186,7 +2183,7 @@ name = "sel4-dlmalloc"
 version = "0.1.0"
 dependencies = [
  "dlmalloc",
- "sel4-sync",
+ "lock_api",
 ]
 
 [[package]]
@@ -2598,6 +2595,7 @@ dependencies = [
 name = "sel4-sync"
 version = "0.1.0"
 dependencies = [
+ "lock_api",
  "sel4",
  "sel4-immediate-sync-once-cell",
 ]

--- a/crates/examples/microkit/http-server/helpers/virtio-hal-impl/src/lib.rs
+++ b/crates/examples/microkit/http-server/helpers/virtio-hal-impl/src/lib.rs
@@ -14,9 +14,9 @@ use virtio_drivers::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
 use sel4_bounce_buffer_allocator::{Basic, BounceBufferAllocator};
 use sel4_externally_shared::{ExternallySharedRef, ExternallySharedRefExt};
 use sel4_immediate_sync_once_cell::ImmediateSyncOnceCell;
-use sel4_sync::{GenericMutex, PanickingMutexSyncOps};
+use sel4_sync::{lock_api::Mutex, GenericRawMutex, PanickingMutexSyncOps};
 
-static GLOBAL_STATE: ImmediateSyncOnceCell<GenericMutex<PanickingMutexSyncOps, State>> =
+static GLOBAL_STATE: ImmediateSyncOnceCell<Mutex<GenericRawMutex<PanickingMutexSyncOps>, State>> =
     ImmediateSyncOnceCell::new();
 
 struct State {
@@ -56,8 +56,8 @@ impl HalImpl {
             BounceBufferAllocator::new(Basic::new(dma_region_size), max_alignment);
 
         GLOBAL_STATE
-            .set(GenericMutex::new(
-                PanickingMutexSyncOps::new(),
+            .set(Mutex::const_new(
+                GenericRawMutex::new(PanickingMutexSyncOps::new()),
                 State {
                     dma_region,
                     dma_region_paddr,

--- a/crates/examples/microkit/http-server/pds/server/Cargo.nix
+++ b/crates/examples/microkit/http-server/pds/server/Cargo.nix
@@ -29,7 +29,6 @@ mk {
 
     inherit (localCrates)
       sel4
-      sel4-sync
       sel4-logging
       sel4-immediate-sync-once-cell
       sel4-microkit-message

--- a/crates/examples/microkit/http-server/pds/server/Cargo.toml
+++ b/crates/examples/microkit/http-server/pds/server/Cargo.toml
@@ -35,7 +35,6 @@ sel4-newlib = { path = "../../../../../sel4-newlib", features = ["nosys", "all-s
 sel4-shared-ring-buffer = { path = "../../../../../sel4-shared-ring-buffer" }
 sel4-shared-ring-buffer-block-io = { path = "../../../../../sel4-shared-ring-buffer/block-io" }
 sel4-shared-ring-buffer-smoltcp = { path = "../../../../../sel4-shared-ring-buffer/smoltcp" }
-sel4-sync = { path = "../../../../../sel4-sync" }
 
 [dependencies.microkit-http-server-example-pl031-driver-interface-types]
 path = "../pl031-driver/interface-types"

--- a/crates/examples/microkit/http-server/pds/virtio-blk-driver/Cargo.nix
+++ b/crates/examples/microkit/http-server/pds/virtio-blk-driver/Cargo.nix
@@ -16,7 +16,6 @@ mk {
     inherit (localCrates)
       sel4-microkit-message
       sel4
-      sel4-sync
       sel4-logging
       sel4-immediate-sync-once-cell
       sel4-shared-ring-buffer

--- a/crates/examples/microkit/http-server/pds/virtio-blk-driver/Cargo.toml
+++ b/crates/examples/microkit/http-server/pds/virtio-blk-driver/Cargo.toml
@@ -28,7 +28,6 @@ sel4-logging = { path = "../../../../../sel4-logging" }
 sel4-microkit = { path = "../../../../../sel4-microkit", default-features = false }
 sel4-microkit-message = { path = "../../../../../sel4-microkit/message" }
 sel4-shared-ring-buffer = { path = "../../../../../sel4-shared-ring-buffer" }
-sel4-sync = { path = "../../../../../sel4-sync" }
 virtio-drivers = { version = "0.5.0", default-features = false }
 
 [dependencies.sel4-shared-ring-buffer-block-io-types]

--- a/crates/examples/microkit/http-server/pds/virtio-net-driver/Cargo.nix
+++ b/crates/examples/microkit/http-server/pds/virtio-net-driver/Cargo.nix
@@ -16,7 +16,6 @@ mk {
     inherit (localCrates)
       sel4-microkit-message
       sel4
-      sel4-sync
       sel4-logging
       sel4-immediate-sync-once-cell
       sel4-shared-ring-buffer

--- a/crates/examples/microkit/http-server/pds/virtio-net-driver/Cargo.toml
+++ b/crates/examples/microkit/http-server/pds/virtio-net-driver/Cargo.toml
@@ -28,5 +28,4 @@ sel4-logging = { path = "../../../../../sel4-logging" }
 sel4-microkit = { path = "../../../../../sel4-microkit", default-features = false }
 sel4-microkit-message = { path = "../../../../../sel4-microkit/message" }
 sel4-shared-ring-buffer = { path = "../../../../../sel4-shared-ring-buffer" }
-sel4-sync = { path = "../../../../../sel4-sync" }
 virtio-drivers = { version = "0.5.0", default-features = false, features = ["alloc"] }

--- a/crates/private/support/sel4-simple-task/runtime/src/global_allocator.rs
+++ b/crates/private/support/sel4-simple-task/runtime/src/global_allocator.rs
@@ -5,23 +5,23 @@
 //
 
 use sel4_dlmalloc::{StaticDlmallocGlobalAlloc, StaticHeapBounds};
-use sel4_sync::AbstractMutexSyncOps;
+use sel4_sync::{AbstractMutexSyncOps, GenericRawMutex};
 
 use crate::{get_static_heap_bounds, get_static_heap_mutex_notification};
 
 #[global_allocator]
 #[allow(clippy::type_complexity)]
 static GLOBAL_ALLOCATOR: StaticDlmallocGlobalAlloc<
-    AbstractMutexSyncOps<fn(), fn()>,
+    GenericRawMutex<AbstractMutexSyncOps<fn(), fn()>>,
     fn() -> StaticHeapBounds,
 > = StaticDlmallocGlobalAlloc::new(
-    AbstractMutexSyncOps {
+    GenericRawMutex::new(AbstractMutexSyncOps {
         signal: || {
             get_static_heap_mutex_notification().signal();
         },
         wait: || {
             get_static_heap_mutex_notification().wait();
         },
-    },
+    }),
     get_static_heap_bounds,
 );

--- a/crates/private/support/sel4-simple-task/runtime/src/lib.rs
+++ b/crates/private/support/sel4-simple-task/runtime/src/lib.rs
@@ -112,8 +112,7 @@ pub fn idle() -> ! {
     abort!("idle failed")
 }
 
-#[no_mangle]
-fn sel4_runtime_abort_hook(info: Option<&AbortInfo>) {
+fn abort_hook(info: Option<&AbortInfo>) {
     match info {
         Some(info) => debug_println!("{}", info),
         None => debug_println!("(aborted)"),
@@ -121,10 +120,13 @@ fn sel4_runtime_abort_hook(info: Option<&AbortInfo>) {
     try_idle()
 }
 
-#[no_mangle]
-fn sel4_runtime_debug_put_char(c: c_char) {
-    sel4::debug_put_char(c)
+sel4_panicking_env::register_abort_hook!(abort_hook);
+
+fn debug_put_char(c: u8) {
+    sel4::debug_put_char(c as c_char)
 }
+
+sel4_panicking_env::register_debug_put_char!(debug_put_char);
 
 fn panic_hook(info: &ExternalPanicInfo<'_>) {
     debug_println!("{}", info);

--- a/crates/private/tests/capdl/threads/components/test/src/main.rs
+++ b/crates/private/tests/capdl/threads/components/test/src/main.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use sel4_simple_task_config_types::*;
 use sel4_simple_task_runtime::{debug_println, main_json};
-use sel4_sync::Mutex;
+use sel4_sync::{lock_api::Mutex, GenericRawMutex};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -32,7 +32,10 @@ const INITIAL_VALUE: i32 = 0;
 fn main(config: Config) {
     debug_println!("{:#?}", config);
 
-    let lock = Arc::new(Mutex::new(config.lock_nfn.get(), INITIAL_VALUE));
+    let lock = Arc::new(Mutex::const_new(
+        GenericRawMutex::new(config.lock_nfn.get()),
+        INITIAL_VALUE,
+    ));
     let barrier_nfn = config.barrier_nfn.get();
 
     config.secondary_thread.get().start({

--- a/crates/private/tests/root-task/tls/src/main.rs
+++ b/crates/private/tests/root-task/tls/src/main.rs
@@ -8,19 +8,24 @@
 #![no_main]
 #![feature(thread_local)]
 
+use core::hint::black_box;
+
 use sel4_root_task::{debug_println, root_task};
 
+const X: i32 = 1337;
+
 #[repr(C, align(4096))]
-struct Y(i32);
+struct T(i32);
 
 #[no_mangle]
 #[thread_local]
-static X: Y = Y(1337);
+static Y: T = T(X);
 
 #[root_task]
 fn main(_: &sel4::BootInfo) -> ! {
-    debug_println!("{}", X.0);
-    assert_eq!(X.0, 1337);
+    let observed = Y.0;
+    debug_println!("{}", observed);
+    assert_eq!(observed, black_box(X));
     debug_println!("TEST_PASS");
     sel4::BootInfo::init_thread_tcb().tcb_suspend().unwrap();
     unreachable!()

--- a/crates/sel4-capdl-initializer/src/main.rs
+++ b/crates/sel4-capdl-initializer/src/main.rs
@@ -113,13 +113,16 @@ fn static_heap_bounds() -> StaticHeapBounds {
 
 mod heap {
     use sel4_dlmalloc::{StaticDlmallocGlobalAlloc, StaticHeapBounds};
-    use sel4_sync::PanickingMutexSyncOps;
+    use sel4_sync::{GenericRawMutex, PanickingMutexSyncOps};
 
     use super::static_heap_bounds;
 
     #[global_allocator]
     static GLOBAL_ALLOCATOR: StaticDlmallocGlobalAlloc<
-        PanickingMutexSyncOps,
+        GenericRawMutex<PanickingMutexSyncOps>,
         fn() -> StaticHeapBounds,
-    > = StaticDlmallocGlobalAlloc::new(PanickingMutexSyncOps::new(), static_heap_bounds);
+    > = StaticDlmallocGlobalAlloc::new(
+        GenericRawMutex::new(PanickingMutexSyncOps::new()),
+        static_heap_bounds,
+    );
 }

--- a/crates/sel4-dlmalloc/Cargo.nix
+++ b/crates/sel4-dlmalloc/Cargo.nix
@@ -4,14 +4,14 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-{ mk, localCrates }:
+{ mk, versions }:
 
 mk {
   package.name = "sel4-dlmalloc";
   dependencies = {
     dlmalloc = "0.2.3";
-    inherit (localCrates)
-      sel4-sync
+    inherit (versions)
+      lock_api
     ;
   };
 }

--- a/crates/sel4-dlmalloc/Cargo.toml
+++ b/crates/sel4-dlmalloc/Cargo.toml
@@ -18,4 +18,4 @@ license = "BSD-2-Clause"
 
 [dependencies]
 dlmalloc = "0.2.3"
-sel4-sync = { path = "../sel4-sync" }
+lock_api = "0.4.11"

--- a/crates/sel4-initialize-tls-on-stack/Cargo.nix
+++ b/crates/sel4-initialize-tls-on-stack/Cargo.nix
@@ -10,8 +10,5 @@ mk {
   package.name = "sel4-initialize-tls-on-stack";
   dependencies = {
     inherit (versions) cfg-if;
-    inherit (localCrates)
-      sel4
-    ;
   };
 }

--- a/crates/sel4-initialize-tls-on-stack/Cargo.toml
+++ b/crates/sel4-initialize-tls-on-stack/Cargo.toml
@@ -18,4 +18,3 @@ license = "BSD-2-Clause"
 
 [dependencies]
 cfg-if = "1.0.0"
-sel4 = { path = "../sel4" }

--- a/crates/sel4-initialize-tls-on-stack/src/lib.rs
+++ b/crates/sel4-initialize-tls-on-stack/src/lib.rs
@@ -10,14 +10,18 @@ use core::arch::{asm, global_asm};
 use core::ffi::c_void;
 use core::slice;
 
-// NOTE
+// TODO
+// Use overflow checking arithmetic ops, and abort!() on overflow
+
 // This is enforced by AArch64 and x86_64
 const STACK_ALIGNMENT: usize = 16;
 
-// NOTE
 // 16 bytes for ELF-level "thread control block"
 // https://akkadia.org/drepper/tls.pdf
-const RESERVED_ABOVE_TPIDR: usize = 16;
+const RESERVED_ABOVE_THREAD_POINTER: usize = 16;
+
+pub type ContFn = unsafe extern "C" fn(*mut c_void) -> !;
+pub type ContArg = *mut c_void;
 
 #[repr(C)]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,42 +34,47 @@ pub struct TlsImage {
 
 impl TlsImage {
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe fn initialize_on_stack_and_continue(&self, cont_fn: ContFn, cont_arg: ContArg) -> ! {
+    pub unsafe fn initialize_on_stack_and_continue<T: SetThreadPointer>(
+        &self,
+        cont_fn: ContFn,
+        cont_arg: ContArg,
+    ) -> ! {
         let args = InternalContArgs {
             tls_image: self as *const TlsImage,
+            set_thread_pointer_fn: T::set_thread_pointer,
             cont_fn,
             cont_arg,
         };
         let segment_size = self.memsz;
         let segment_align_down_mask = !(self.align - 1);
-        let reserved_above_tp = RESERVED_ABOVE_TPIDR;
+        let reserved_above_thread_pointer = RESERVED_ABOVE_THREAD_POINTER;
         let stack_align_down_mask = !(STACK_ALIGNMENT - 1);
         __sel4_runtime_initialize_tls_and_continue(
             &args as *const InternalContArgs,
             segment_size,
             segment_align_down_mask,
-            reserved_above_tp,
+            reserved_above_thread_pointer,
             stack_align_down_mask,
             continue_with,
         )
     }
 
-    fn tls_base_addr(&self, tp: usize) -> usize {
+    fn tls_base_addr(&self, thread_pointer: usize) -> usize {
         cfg_if::cfg_if! {
             if #[cfg(target_arch = "aarch64")] {
-                (tp + RESERVED_ABOVE_TPIDR).next_multiple_of(self.align)
+                (thread_pointer + RESERVED_ABOVE_THREAD_POINTER).next_multiple_of(self.align)
             } else if #[cfg(any(target_arch = "riscv64", target_arch = "riscv32"))] {
-                tp.next_multiple_of(self.align)
+                thread_pointer.next_multiple_of(self.align)
             } else if #[cfg(target_arch = "x86_64")] {
-                (tp - self.memsz) & !(self.align - 1)
+                (thread_pointer - self.memsz) & !(self.align - 1)
             } else {
                 compile_error!("unsupported architecture");
             }
         }
     }
 
-    unsafe fn init(&self, tp: usize) {
-        let addr = self.tls_base_addr(tp);
+    unsafe fn init(&self, thread_pointer: usize) {
+        let addr = self.tls_base_addr(thread_pointer);
         let window = slice::from_raw_parts_mut(addr as *mut _, self.memsz);
         let (tdata, tbss) = window.split_at_mut(self.filesz);
         tdata.copy_from_slice(self.data());
@@ -77,13 +86,11 @@ impl TlsImage {
     }
 }
 
-pub type ContFn = unsafe extern "C" fn(*mut c_void) -> !;
-pub type ContArg = *mut c_void;
-
 #[repr(C)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct InternalContArgs {
     tls_image: *const TlsImage,
+    set_thread_pointer_fn: unsafe extern "C" fn(val: usize),
     cont_fn: ContFn,
     cont_arg: ContArg,
 }
@@ -93,9 +100,12 @@ extern "C" {
         args: *const InternalContArgs,
         segment_size: usize,
         segment_align_down_mask: usize,
-        reserved_above_tp: usize,
+        reserved_above_thread_pointer: usize,
         stack_align_down_mask: usize,
-        continue_with: unsafe extern "C" fn(args: *const InternalContArgs, tp: usize) -> !,
+        continue_with: unsafe extern "C" fn(
+            args: *const InternalContArgs,
+            thread_pointer: usize,
+        ) -> !,
     ) -> !;
 }
 
@@ -111,12 +121,12 @@ cfg_if::cfg_if! {
                     mov x9, sp
                     sub x9, x9, x1 // x1: segment_size
                     and x9, x9, x2 // x2: segment_align_down_mask
-                    sub x9, x9, x3 // x3: reserved_above_tp
+                    sub x9, x9, x3 // x3: reserved_above_thread_pointer
                     and x9, x9, x2 // x2: segment_align_down_mask
-                    mov x10, x9    // save tp for later
+                    mov x10, x9    // save thread pointer for later
                     and x9, x9, x4 // x4: stack_align_down_mask
                     mov sp, x9
-                    mov x1, x10    // pass tp to continuation
+                    mov x1, x10    // pass thread pointer to continuation
                     br x5
             "#
         }
@@ -131,12 +141,12 @@ cfg_if::cfg_if! {
                     mv s9, sp
                     sub s9, s9, a1 // a1: segment_size
                     and s9, s9, a2 // a2: segment_align_down_mask
-                    sub s9, s9, a3 // a3: reserved_above_tp
+                    sub s9, s9, a3 // a3: reserved_above_thread_pointer
                     and s9, s9, a2 // a2: segment_align_down_mask
-                    mv s10, s9     // save tp for later
+                    mv s10, s9     // save thread pointer for later
                     and s9, s9, a4 // a4: stack_align_down_mask
                     mv sp, s9
-                    mv a1, s10     // pass tp to continuation
+                    mv a1, s10     // pass thread pointer to continuation
                     jr a5
             "#
         }
@@ -151,12 +161,12 @@ cfg_if::cfg_if! {
                     mov r10, rsp
                     sub r10, 0x8 // space for thread structure
                     and r10, rdx // rdx: segment_align_down_mask
-                    mov r11, r10 // save tp for later
+                    mov r11, r10 // save thread_pointer for later
                     sub r10, rsi // rsi: segment_size
                     and r10, rdx // rdx: segment_align_down_mask
                     and r10, r8  // r8: stack_align_down_mask
                     mov rsp, r10
-                    mov rsi, r11 // pass tp to continuation
+                    mov rsi, r11 // pass thread pointer to continuation
                     mov rbp, rsp
                     sub rsp, 0x8 // stack must be 16-byte aligned before call
                     push rbp
@@ -168,95 +178,43 @@ cfg_if::cfg_if! {
     }
 }
 
-unsafe extern "C" fn continue_with(args: *const InternalContArgs, tp: usize) -> ! {
+unsafe extern "C" fn continue_with(args: *const InternalContArgs, thread_pointer: usize) -> ! {
     let args = unsafe { &*args };
     let tls_image = unsafe { &*args.tls_image };
-    tls_image.init(tp);
+    tls_image.init(thread_pointer);
 
-    set_thread_pointer(tp);
+    (args.set_thread_pointer_fn)(thread_pointer);
 
     if cfg!(target_arch = "x86_64") {
-        (tp as *mut usize).write(tp);
+        (thread_pointer as *mut usize).write(thread_pointer);
     }
 
     (args.cont_fn)(args.cont_arg)
 }
 
-// helpers
+pub trait SetThreadPointer {
+    unsafe extern "C" fn set_thread_pointer(val: usize);
+}
 
-// NOTE
-// The Rust optimizer has caused issues here. For example, thread local accesses below being emitted
-// before this call. Fences in core::sync::atomic didn't work, but a get_thread_pointer() call did.
-// For now, making this function #[inline(never)] seems to be sufficient.
+pub struct DefaultSetThreadPointer(());
 
-cfg_if::cfg_if! {
-    if #[cfg(target_arch = "aarch64")] {
+#[cfg(target_arch = "aarch64")]
+impl SetThreadPointer for DefaultSetThreadPointer {
+    unsafe extern "C" fn set_thread_pointer(val: usize) {
+        asm!("msr tpidr_el0, {val}", val = in(reg) val);
+    }
+}
 
-        #[inline(never)] // issues with optimizer
-        unsafe fn set_thread_pointer(tp: usize) {
-            asm!("msr tpidr_el0, {tp}", tp = in(reg) tp);
-        }
+#[cfg(any(target_arch = "riscv64", target_arch = "riscv32"))]
+impl SetThreadPointer for DefaultSetThreadPointer {
+    unsafe extern "C" fn set_thread_pointer(val: usize) {
+        asm!("mv tp, {val}", val = in(reg) val);
+    }
+}
 
-        #[allow(dead_code)]
-        #[inline(never)] // issues with optimizer
-        unsafe fn get_thread_pointer() -> usize {
-            let mut tp;
-            asm!("mrs {tp}, tpidr_el0", tp = out(reg) tp);
-            tp
-        }
-
-    } else if #[cfg(any(target_arch = "riscv64", target_arch = "riscv32"))] {
-
-        #[inline(never)] // issues with optimizer
-        unsafe fn set_thread_pointer(tp: usize) {
-            asm!("mv tp, {tp}", tp = in(reg) tp);
-        }
-
-        #[allow(dead_code)]
-        #[inline(never)] // issues with optimizer
-        unsafe fn get_thread_pointer() -> usize {
-            let mut tp;
-            asm!("mv {tp}, tp", tp = out(reg) tp);
-            tp
-        }
-
-    } else if #[cfg(target_arch = "x86_64")] {
-
-        sel4::sel4_cfg_if! {
-            if #[cfg(FSGSBASE_INST)] {
-
-                #[inline(never)] // issues with optimizer
-                unsafe fn set_thread_pointer(val: usize) {
-                    asm!("wrfsbase {val}", val = in(reg) val);
-                }
-
-                #[allow(dead_code)]
-                #[inline(never)] // issues with optimizer
-                unsafe fn get_thread_pointer() -> usize {
-                    let mut val;
-                    asm!("rdfsbase {val}", val = out(reg) val);
-                    val
-                }
-
-            } else if #[cfg(SET_TLS_BASE_SELF)] {
-
-                unsafe fn set_thread_pointer(val: usize) {
-                    sel4::sys::seL4_SetTLSBase(val.try_into().unwrap());
-                }
-
-                #[allow(dead_code)]
-                #[inline(never)] // issues with optimizer
-                unsafe fn get_thread_pointer() -> usize {
-                    let mut val;
-                    asm!("mov {val}, fs:0", val = out(reg) val);
-                    val
-                }
-
-            } else {
-                compile_error!("unsupported configuraton");
-            }
-        }
-    } else {
-        compile_error!("unsupported architecture");
+#[cfg(target_arch = "x86_64")]
+impl SetThreadPointer for DefaultSetThreadPointer {
+    unsafe extern "C" fn set_thread_pointer(val: usize) {
+        asm!("wrfsbase {val}", val = in(reg) val);
     }
 }

--- a/crates/sel4-microkit/src/entry.rs
+++ b/crates/sel4-microkit/src/entry.rs
@@ -14,16 +14,11 @@ use crate::panicking::init_panicking;
 #[cfg(target_thread_local)]
 #[no_mangle]
 unsafe extern "C" fn sel4_runtime_rust_entry() -> ! {
-    use core::ffi::c_void;
-    use core::ptr;
-
-    unsafe extern "C" fn cont_fn(_cont_arg: *mut c_void) -> ! {
+    unsafe extern "C" fn cont_fn(_cont_arg: *mut sel4_runtime_common::ContArg) -> ! {
         inner_entry()
     }
 
-    let cont_arg = ptr::null_mut();
-
-    sel4_runtime_common::initialize_tls_on_stack_and_continue(cont_fn, cont_arg)
+    sel4_runtime_common::initialize_tls_on_stack_and_continue(cont_fn, core::ptr::null_mut())
 }
 
 #[cfg(not(target_thread_local))]

--- a/crates/sel4-microkit/src/entry.rs
+++ b/crates/sel4-microkit/src/entry.rs
@@ -23,9 +23,7 @@ unsafe extern "C" fn sel4_runtime_rust_entry() -> ! {
 
     let cont_arg = ptr::null_mut();
 
-    sel4_runtime_common::locate_tls_image()
-        .unwrap()
-        .initialize_on_stack_and_continue(cont_fn, cont_arg)
+    sel4_runtime_common::initialize_tls_on_stack_and_continue(cont_fn, cont_arg)
 }
 
 #[cfg(not(target_thread_local))]

--- a/crates/sel4-microkit/src/panicking.rs
+++ b/crates/sel4-microkit/src/panicking.rs
@@ -40,12 +40,12 @@ pub(crate) fn init_panicking() {
 
 // // //
 
-#[no_mangle]
-#[allow(unused_variables)]
-fn sel4_runtime_debug_put_char(c: u8) {
+fn debug_put_char(c: u8) {
     sel4::sel4_cfg_if! {
         if #[cfg(PRINTING)] {
             sel4::debug_put_char(c as core::ffi::c_char)
         }
     }
 }
+
+sel4_panicking_env::register_debug_put_char!(debug_put_char);

--- a/crates/sel4-panicking/env/src/lib.rs
+++ b/crates/sel4-panicking/env/src/lib.rs
@@ -91,13 +91,14 @@ impl<'a> AbortInfo<'a> {
 impl fmt::Display for AbortInfo<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("aborted at ")?;
-        if let Some(message) = self.message {
-            write!(f, "'{message}', ")?;
-        }
         if let Some(location) = self.location {
             location.fmt(f)?;
         } else {
-            write!(f, "unknown location")?;
+            f.write_str("unknown location")?;
+        }
+        if let Some(message) = self.message {
+            f.write_str(":\n")?;
+            f.write_fmt(*message)?;
         }
         Ok(())
     }

--- a/crates/sel4-panicking/src/lib.rs
+++ b/crates/sel4-panicking/src/lib.rs
@@ -66,13 +66,14 @@ impl<'a> ExternalPanicInfo<'a> {
 impl fmt::Display for ExternalPanicInfo<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("panicked at ")?;
-        if let Some(message) = self.message {
-            write!(f, "'{message}', ")?;
-        }
         if let Some(location) = self.location {
             location.fmt(f)?;
         } else {
-            write!(f, "unknown location")?;
+            f.write_str("unknown location")?;
+        }
+        if let Some(message) = self.message {
+            f.write_str(":\n")?;
+            f.write_fmt(*message)?;
         }
         Ok(())
     }

--- a/crates/sel4-root-task/src/lib.rs
+++ b/crates/sel4-root-task/src/lib.rs
@@ -34,9 +34,7 @@ unsafe extern "C" fn sel4_runtime_rust_entry(bootinfo: *const sel4::sys::seL4_Bo
 
     let cont_arg = bootinfo.cast::<c_void>().cast_mut();
 
-    sel4_runtime_common::locate_tls_image()
-        .unwrap()
-        .initialize_on_stack_and_continue(cont_fn, cont_arg)
+    sel4_runtime_common::initialize_tls_on_stack_and_continue(cont_fn, cont_arg)
 }
 
 #[cfg(not(target_thread_local))]

--- a/crates/sel4-root-task/src/lib.rs
+++ b/crates/sel4-root-task/src/lib.rs
@@ -85,10 +85,11 @@ pub unsafe fn run_main<T>(
     }
 }
 
-#[no_mangle]
-fn sel4_runtime_debug_put_char(c: u8) {
+fn debug_put_char(c: u8) {
     sel4::debug_put_char(c as c_char)
 }
+
+sel4_panicking_env::register_debug_put_char!(debug_put_char);
 
 #[macro_export]
 macro_rules! declare_root_task {

--- a/crates/sel4-runtime-common/Cargo.nix
+++ b/crates/sel4-runtime-common/Cargo.nix
@@ -11,12 +11,14 @@ mk {
   dependencies = {
     inherit (versions) cfg-if;
     unwinding = unwindingWith [] // { optional = true; };
+    inherit (localCrates) sel4-panicking-env;
+    sel4 = localCrates.sel4 // { default-features = false; optional = true; };
     sel4-initialize-tls-on-stack = localCrates.sel4-initialize-tls-on-stack // { optional = true; };
     sel4-sync = localCrates.sel4-sync // { optional = true; };
     sel4-dlmalloc = localCrates.sel4-dlmalloc // { optional = true; };
   };
   features = {
-    tls = [ "dep:sel4-initialize-tls-on-stack" ];
+    tls = [ "dep:sel4-initialize-tls-on-stack" "dep:sel4" ];
     start = [];
     static-heap = [ "sel4-sync" "sel4-dlmalloc" ];
   };

--- a/crates/sel4-runtime-common/Cargo.toml
+++ b/crates/sel4-runtime-common/Cargo.toml
@@ -19,12 +19,14 @@ license = "BSD-2-Clause"
 [features]
 start = []
 static-heap = ["sel4-sync", "sel4-dlmalloc"]
-tls = ["dep:sel4-initialize-tls-on-stack"]
+tls = ["dep:sel4-initialize-tls-on-stack", "dep:sel4"]
 
 [dependencies]
 cfg-if = "1.0.0"
+sel4 = { path = "../sel4", default-features = false, optional = true }
 sel4-dlmalloc = { path = "../sel4-dlmalloc", optional = true }
 sel4-initialize-tls-on-stack = { path = "../sel4-initialize-tls-on-stack", optional = true }
+sel4-panicking-env = { path = "../sel4-panicking/env" }
 sel4-sync = { path = "../sel4-sync", optional = true }
 
 [dependencies.unwinding]

--- a/crates/sel4-runtime-common/src/phdrs/elf.rs
+++ b/crates/sel4-runtime-common/src/phdrs/elf.rs
@@ -9,6 +9,8 @@
 use core::ops::Range;
 use core::slice;
 
+use sel4_panicking_env::abort;
+
 #[cfg(target_pointer_width = "32")]
 pub type Word = u32;
 
@@ -57,7 +59,7 @@ impl ElfHeader {
         unsafe {
             let ptr = (self as *const Self)
                 .cast::<u8>()
-                .offset(self.e_phoff.try_into().unwrap())
+                .offset(self.e_phoff.try_into().unwrap_or_else(|_| abort!()))
                 .cast::<ProgramHeader>();
             slice::from_raw_parts(ptr, self.e_phnum.into())
         }
@@ -89,6 +91,6 @@ impl ProgramHeader {
     pub fn vaddr_range(&self) -> Range<usize> {
         let start = self.p_vaddr;
         let end = start + self.p_memsz;
-        start.try_into().unwrap()..end.try_into().unwrap()
+        start.try_into().unwrap_or_else(|_| abort!())..end.try_into().unwrap_or_else(|_| abort!())
     }
 }

--- a/crates/sel4-runtime-common/src/phdrs/mod.rs
+++ b/crates/sel4-runtime-common/src/phdrs/mod.rs
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
+use sel4_panicking_env::abort;
+
 mod elf;
 
 use elf::{ElfHeader, ProgramHeader};
@@ -12,7 +14,7 @@ use elf::{ElfHeader, ProgramHeader};
 mod tls;
 
 #[cfg(all(feature = "tls", target_thread_local))]
-pub use tls::locate_tls_image;
+pub use tls::initialize_tls_on_stack_and_continue;
 
 #[cfg(feature = "unwinding")]
 mod unwinding;
@@ -25,7 +27,9 @@ pub(crate) fn locate_phdrs() -> &'static [ProgramHeader] {
         static __ehdr_start: ElfHeader;
     }
     unsafe {
-        assert!(__ehdr_start.check_magic());
+        if !__ehdr_start.check_magic() {
+            abort!()
+        }
         __ehdr_start.locate_phdrs()
     }
 }

--- a/crates/sel4-runtime-common/src/phdrs/mod.rs
+++ b/crates/sel4-runtime-common/src/phdrs/mod.rs
@@ -28,7 +28,7 @@ pub(crate) fn locate_phdrs() -> &'static [ProgramHeader] {
     }
     unsafe {
         if !__ehdr_start.check_magic() {
-            abort!()
+            abort!("ELF header magic mismatch")
         }
         __ehdr_start.locate_phdrs()
     }

--- a/crates/sel4-runtime-common/src/phdrs/mod.rs
+++ b/crates/sel4-runtime-common/src/phdrs/mod.rs
@@ -14,7 +14,7 @@ use elf::{ElfHeader, ProgramHeader};
 mod tls;
 
 #[cfg(all(feature = "tls", target_thread_local))]
-pub use tls::initialize_tls_on_stack_and_continue;
+pub use tls::{initialize_tls_on_stack_and_continue, ContArg, ContFn};
 
 #[cfg(feature = "unwinding")]
 mod unwinding;

--- a/crates/sel4-runtime-common/src/phdrs/tls.rs
+++ b/crates/sel4-runtime-common/src/phdrs/tls.rs
@@ -4,11 +4,16 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
-use sel4_initialize_tls_on_stack::TlsImage;
+use sel4_panicking_env::abort;
+
+#[allow(unused_imports)]
+use sel4_initialize_tls_on_stack::{
+    ContArg, ContFn, DefaultSetThreadPointer, SetThreadPointer, TlsImage,
+};
 
 use crate::phdrs::{elf::PT_TLS, locate_phdrs};
 
-pub fn locate_tls_image() -> Option<TlsImage> {
+pub unsafe fn initialize_tls_on_stack_and_continue(cont_fn: ContFn, cont_arg: ContArg) -> ! {
     locate_phdrs()
         .iter()
         .find(|phdr| phdr.p_type == PT_TLS)
@@ -18,4 +23,22 @@ pub fn locate_tls_image() -> Option<TlsImage> {
             memsz: phdr.p_memsz.try_into().unwrap(),
             align: phdr.p_align.try_into().unwrap(),
         })
+        .unwrap_or_else(|| abort!())
+        .initialize_on_stack_and_continue::<ChosenSetThreadPointer>(cont_fn, cont_arg)
+}
+
+sel4::sel4_cfg_if! {
+    if #[cfg(all(ARCH_X86_64, SET_TLS_BASE_SELF))] {
+        type ChosenSetThreadPointer = SyscallSetThreadPointer;
+
+        struct SyscallSetThreadPointer;
+
+        impl SetThreadPointer for SyscallSetThreadPointer {
+            unsafe extern "C" fn set_thread_pointer(val: usize) {
+                sel4::sys::seL4_SetTLSBase(val.try_into().unwrap());
+            }
+        }
+    } else {
+        type ChosenSetThreadPointer = DefaultSetThreadPointer;
+    }
 }

--- a/crates/sel4-runtime-common/src/static_heap.rs
+++ b/crates/sel4-runtime-common/src/static_heap.rs
@@ -5,19 +5,24 @@
 //
 
 use sel4_dlmalloc::StaticDlmallocGlobalAlloc;
-use sel4_sync::DeferredNotificationMutexSyncOps;
+use sel4_sync::{DeferredNotificationMutexSyncOps, GenericRawMutex};
 
 pub use sel4_dlmalloc::StaticHeap;
 
 #[doc(hidden)]
-pub type GlobalAllocator<const N: usize> =
-    StaticDlmallocGlobalAlloc<DeferredNotificationMutexSyncOps, &'static StaticHeap<N>>;
+pub type GlobalAllocator<const N: usize> = StaticDlmallocGlobalAlloc<
+    GenericRawMutex<DeferredNotificationMutexSyncOps>,
+    &'static StaticHeap<N>,
+>;
 
 #[doc(hidden)]
 pub const fn new_global_allocator<const N: usize>(
     bounds: &'static StaticHeap<N>,
 ) -> GlobalAllocator<N> {
-    StaticDlmallocGlobalAlloc::new(DeferredNotificationMutexSyncOps::new(), bounds)
+    StaticDlmallocGlobalAlloc::new(
+        GenericRawMutex::new(DeferredNotificationMutexSyncOps::new()),
+        bounds,
+    )
 }
 
 #[macro_export]

--- a/crates/sel4-sync/Cargo.nix
+++ b/crates/sel4-sync/Cargo.nix
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 #
 
-{ mk, mkDefaultFrontmatterWithReuseArgs, defaultReuseFrontmatterArgs, localCrates }:
+{ mk, mkDefaultFrontmatterWithReuseArgs, defaultReuseFrontmatterArgs, versions, localCrates }:
 
 mk rec {
   nix.frontmatter = mkDefaultFrontmatterWithReuseArgs (defaultReuseFrontmatterArgs // {
@@ -13,6 +13,7 @@ mk rec {
   package.name = "sel4-sync";
   package.license = "MIT";
   dependencies = {
+    inherit (versions) lock_api;
     inherit (localCrates)
       sel4
       sel4-immediate-sync-once-cell

--- a/crates/sel4-sync/Cargo.toml
+++ b/crates/sel4-sync/Cargo.toml
@@ -17,5 +17,6 @@ edition = "2021"
 license = "MIT"
 
 [dependencies]
+lock_api = "0.4.11"
 sel4 = { path = "../sel4" }
 sel4-immediate-sync-once-cell = { path = "../sel4-immediate-sync-once-cell" }

--- a/crates/sel4-sync/src/lib.rs
+++ b/crates/sel4-sync/src/lib.rs
@@ -6,11 +6,12 @@
 
 #![no_std]
 
+pub use lock_api;
+
 mod mutex;
 
 pub use mutex::{
-    AbstractMutexSyncOps, DeferredMutex, DeferredMutexGuard, DeferredNotificationMutexSyncOps,
-    GenericMutex, GenericMutexGuard, IndirectNotificationMutexSyncOps, Mutex, MutexGuard,
-    MutexSyncOps, MutexSyncOpsWithInteriorMutability, MutexSyncOpsWithNotification,
-    PanickingMutexSyncOps,
+    AbstractMutexSyncOps, DeferredNotificationMutexSyncOps, GenericRawMutex,
+    IndirectNotificationMutexSyncOps, MutexSyncOps, MutexSyncOpsWithInteriorMutability,
+    MutexSyncOpsWithNotification, PanickingMutexSyncOps,
 };

--- a/hacking/cargo-manifest-management/manifest-scope.nix
+++ b/hacking/cargo-manifest-management/manifest-scope.nix
@@ -96,6 +96,7 @@ in rec {
     getrandom = "0.2.10";
     gimli = "0.28.0";
     heapless = "0.7.16";
+    lock_api = "0.4.11";
     log = "0.4.17";
     num = "0.4.1";
     num_enum = "0.5.9";

--- a/hacking/cargo-manifest-management/manual-manifests.nix
+++ b/hacking/cargo-manifest-management/manual-manifests.nix
@@ -13,4 +13,5 @@ let
 in {
   # ring = relativeToTmpSrc "ring";
   # rustls = relativeToTmpSrc "rustls/rustls";
+  # lock_api = relativeToTmpSrc "parking_lot/lock_api";
 }

--- a/hacking/nix/scope/world/instances/default.nix
+++ b/hacking/nix/scope/world/instances/default.nix
@@ -108,7 +108,7 @@ in rec {
       tls = maybe haveFullRuntime (mkInstance {
         rootTask = mkTask {
           rootCrate = crates.tests-root-task-tls;
-          release = false;
+          release = true; # test optimizations
         };
         extraPlatformArgs = lib.optionalAttrs canSimulate {
           canAutomateSimply = true;
@@ -254,6 +254,7 @@ in rec {
           passthru = {
             test = mkTask {
               rootCrate = crates.tests-capdl-threads-components-test;
+              release = true; # test optimizations
             };
           };
         };


### PR DESCRIPTION
- Reduce transitive dependencies on the `sel4` crate (this improves modularity and testability, and will make stabilizing APIs easier)
- General code clean-up