### PR TITLE
Enable `sel4-panicking` crate to work with more rustc versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2389,6 +2389,7 @@ name = "sel4-panicking"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
+ "rustc_version",
  "sel4-immediate-sync-once-cell",
  "sel4-panicking-env",
  "unwinding",

--- a/crates/sel4-panicking/Cargo.nix
+++ b/crates/sel4-panicking/Cargo.nix
@@ -15,6 +15,9 @@ mk {
       sel4-immediate-sync-once-cell
     ;
   };
+  build-dependencies = {
+    inherit (versions) rustc_version;
+  };
   target."cfg(not(target_arch = \"arm\"))".dependencies = {
     unwinding = unwindingWith [ "personality" ] // { optional = true; };
   };

--- a/crates/sel4-panicking/Cargo.toml
+++ b/crates/sel4-panicking/Cargo.toml
@@ -24,6 +24,9 @@ cfg-if = "1.0.0"
 sel4-immediate-sync-once-cell = { path = "../sel4-immediate-sync-once-cell" }
 sel4-panicking-env = { path = "env" }
 
+[build-dependencies]
+rustc_version = "0.4.0"
+
 [target."cfg(not(target_arch = \"arm\"))".dependencies.unwinding]
 version = "0.1.6"
 default-features = false

--- a/crates/sel4-panicking/build.rs
+++ b/crates/sel4-panicking/build.rs
@@ -1,0 +1,25 @@
+//
+// Copyright 2024, Colias Group, LLC
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+
+use core::cmp::Reverse;
+
+// Determine whether rustc includes https://github.com/rust-lang/rust/pull/121598
+
+fn main() {
+    let version_meta = rustc_version::version_meta().unwrap();
+    let semver = version_meta.semver;
+    let commit_date = order_date(version_meta.commit_date);
+    let key = (semver.major, semver.minor, semver.patch, commit_date);
+    let first_with_change = (1, 78, 0, order_date(Some("2024-02-28".to_owned())));
+    if key < first_with_change {
+        println!("cargo:rustc-cfg=catch_unwind_intrinsic_still_named_try");
+    }
+}
+
+// assume no build date means more recent
+fn order_date(date: Option<String>) -> Reverse<Option<Reverse<String>>> {
+    Reverse(date.map(Reverse))
+}

--- a/hacking/cargo-manifest-management/manifest-scope.nix
+++ b/hacking/cargo-manifest-management/manifest-scope.nix
@@ -107,6 +107,7 @@ in rec {
     proc-macro2 = "1.0.50";
     quote = "1.0.23";
     rand = "0.8.5";
+    rustc_version = "0.4.0";
     serde = "1.0.147";
     serde_json = "1.0.87";
     serde_yaml = "0.9.14";


### PR DESCRIPTION
Add `build.rs` that determines which side of https://github.com/rust-lang/rust/pull/121598 the toolchain is on.