### PR TITLE
capdl: set notification on x86 IRQ handlers

### DIFF
--- a/crates/sel4-capdl-initializer/core/src/lib.rs
+++ b/crates/sel4-capdl-initializer/core/src/lib.rs
@@ -416,8 +416,20 @@ impl<'a, N: ObjectName, D: Content, M: GetEmbeddedFrame, B: BorrowMut<[PerObject
             .spec()
             .filter_objects::<&object::ArmIrq>()
             .map(|(obj_id, obj)| (obj_id, obj.notification()));
+        let msi_irq_notifications = self
+            .spec()
+            .filter_objects::<&object::IrqMsi>()
+            .map(|(obj_id, obj)| (obj_id, obj.notification()));
+        let ioapic_irq_notifications = self
+            .spec()
+            .filter_objects::<&object::IrqIOApic>()
+            .map(|(obj_id, obj)| (obj_id, obj.notification()));
 
-        for (obj_id, notification) in irq_notifications.chain(arm_irq_notifications) {
+        let all_irq_notifications = irq_notifications
+            .chain(arm_irq_notifications)
+            .chain(msi_irq_notifications)
+            .chain(ioapic_irq_notifications);
+        for (obj_id, notification) in all_irq_notifications {
             let irq_handler = self.orig_cap::<cap_type::IrqHandler>(obj_id);
             if let Some(logical_nfn_cap) = notification {
                 let nfn = match logical_nfn_cap.badge {

--- a/crates/sel4-capdl-initializer/types/src/cap_table.rs
+++ b/crates/sel4-capdl-initializer/types/src/cap_table.rs
@@ -104,6 +104,22 @@ impl<'a> object::ArmIrq<'a> {
     }
 }
 
+impl<'a> object::IrqMsi<'a> {
+    pub const SLOT_NOTIFICATION: CapSlot = 0;
+
+    pub fn notification(&self) -> Option<&cap::Notification> {
+        self.maybe_slot_as(Self::SLOT_NOTIFICATION)
+    }
+}
+
+impl<'a> object::IrqIOApic<'a> {
+    pub const SLOT_NOTIFICATION: CapSlot = 0;
+
+    pub fn notification(&self) -> Option<&cap::Notification> {
+        self.maybe_slot_as(Self::SLOT_NOTIFICATION)
+    }
+}
+
 // // //
 
 impl<'a> object::PageTable<'a> {


### PR DESCRIPTION
Forgot to add in https://github.com/seL4/rust-sel4/pull/96.

We're still having issues trying to get IRQs on x86. Most likely a mistake in the capDL spec rather than the initialiser, but will make further patches if needed.

This missing code is definitely part of the issue though.