### PR TITLE
Fix release mode warnings and compile errors

### DIFF
--- a/crates/sel4-capdl-initializer/core/src/lib.rs
+++ b/crates/sel4-capdl-initializer/core/src/lib.rs
@@ -736,8 +736,12 @@ impl<'a, N: ObjectName, D: Content, M: GetEmbeddedFrame, B: BorrowMut<[PerObject
                 tcb.tcb_write_all_registers(false, &mut regs)?;
             }
 
-            if let Some(name) = self.object_name(self.spec().name(obj_id)) {
-                tcb.debug_name(name.as_bytes());
+            sel4::sel4_cfg_if! {
+                if #[sel4_cfg(PRINTING)] {
+                    if let Some(name) = self.object_name(self.spec().name(obj_id)) {
+                        tcb.debug_name(name.as_bytes());
+                    }
+                }
             }
         }
         Ok(())

--- a/crates/sel4-capdl-initializer/src/main.rs
+++ b/crates/sel4-capdl-initializer/src/main.rs
@@ -23,6 +23,18 @@ use sel4_dlmalloc::StaticHeapBounds;
 use sel4_logging::{LevelFilter, Logger, LoggerBuilder};
 use sel4_root_task::root_task;
 
+sel4::config::sel4_cfg_if! {
+    if #[sel4_cfg(PRINTING)] {
+        pub use sel4::debug_print;
+    } else {
+        /// No-op for this configuration.
+        #[macro_export]
+        macro_rules! debug_print {
+            ($($arg:tt)*) => {};
+        }
+    }
+}
+
 const LOG_LEVEL: LevelFilter = {
     // LevelFilter::Trace
     // LevelFilter::Debug
@@ -32,7 +44,9 @@ const LOG_LEVEL: LevelFilter = {
 static LOGGER: Logger = LoggerBuilder::const_default()
     .level_filter(LOG_LEVEL)
     .filter(|meta| meta.target() == "sel4_capdl_initializer_core")
-    .write(|s| sel4::debug_print!("{}", s))
+    .write(|_s| {
+        debug_print!("{}", _s);
+    })
     .build();
 
 #[root_task(stack_size = 0x10000)]

--- a/crates/sel4-root-task/src/lib.rs
+++ b/crates/sel4-root-task/src/lib.rs
@@ -20,8 +20,13 @@ mod printing;
 mod termination;
 
 pub use heap::set_global_allocator_mutex_notification;
-pub use printing::{debug_print, debug_println};
 pub use termination::{Never, Termination};
+
+sel4::config::sel4_cfg_if! {
+    if #[sel4_cfg(PRINTING)] {
+        pub use printing::{debug_print, debug_println};
+    }
+}
 
 #[macro_export]
 macro_rules! declare_root_task {

--- a/crates/sel4/sys/src/ipc_buffer.rs
+++ b/crates/sel4/sys/src/ipc_buffer.rs
@@ -45,6 +45,7 @@ impl seL4_IPCBuffer {
         set_bits_from_slice(&mut self.msg, range, value, 0)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn msg_bytes_mut(&mut self) -> &'static mut [u8] {
         let msg = &mut self.msg;
         unsafe {

--- a/crates/sel4/sys/src/syscalls/calls.rs
+++ b/crates/sel4/sys/src/syscalls/calls.rs
@@ -9,6 +9,7 @@ use core::sync::atomic::{compiler_fence, Ordering};
 
 use sel4_config::{sel4_cfg, sel4_cfg_if};
 
+#[allow(unused_imports)]
 use crate::{
     seL4_CPtr, seL4_IPCBuffer, seL4_MessageInfo, seL4_Uint32, seL4_Word, syscall_id,
     ReplyAuthority, WaitMessageInfo,
@@ -122,6 +123,7 @@ macro_rules! fence {
     };
 }
 
+#[allow(dead_code)]
 fn sys_send_recv_simple(sys_id: c_int, arg: seL4_Word) -> seL4_Word {
     let mut mr0 = 0;
     let mut mr1 = 0;


### PR DESCRIPTION
Regarding print macros not being available in release mode, I went with a similar approach as `crates/sel4-microkit/src/printing.rs`.