### PR TITLE
Add missing kernel config includes

### DIFF
--- a/crates/sel4-kernel-loader/asm/aarch32/head.S
+++ b/crates/sel4-kernel-loader/asm/aarch32/head.S
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
+#include <kernel/gen_config.h>
+
 #include "macros.h"
 #include "registers.h"
 #include "mm.h"

--- a/crates/sel4-kernel-loader/asm/aarch64/mm.h
+++ b/crates/sel4-kernel-loader/asm/aarch64/mm.h
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: GPL-2.0-only
  */
 
+#include <kernel/gen_config.h>
+
 #include "registers.h"
 
 #ifdef CONFIG_ARM_PA_SIZE_BITS_40


### PR DESCRIPTION
This omission was discovered when the kernel loader causing the kernel to crash on odroid-c2 which has `CONFIG_ARM_PA_SIZE_BITS_40`.