### PR TITLE
Remove unecessary `#[feature(thread_local)]` from `sel4-sys`

### DIFF
--- a/crates/sel4/sys/src/lib.rs
+++ b/crates/sel4/sys/src/lib.rs
@@ -5,7 +5,6 @@
 //
 
 #![no_std]
-#![feature(thread_local)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]


### PR DESCRIPTION
Unnecessary since `sel4test` support was relegated to a branch