### PR TITLE
fix typo in set_recv_slot

### DIFF
--- a/crates/sel4/src/ipc_buffer.rs
+++ b/crates/sel4/src/ipc_buffer.rs
@@ -66,6 +66,6 @@ impl IpcBuffer {
         let inner = self.inner_mut();
         inner.receiveCNode = slot.root().bits();
         inner.receiveIndex = slot.path().bits();
-        inner.receiveCNode = slot.path().depth().try_into().unwrap();
+        inner.receiveDepth = slot.path().depth().try_into().unwrap();
     }
 }


### PR DESCRIPTION
The implementation was setting the root cnode twice instead of setting the depth.