### PR TITLE
Update `ring` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,9 +340,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "c891175c3fb232128f48de6590095e59198bbeb8620c310be349bfc3afd12c7b"
 
 [[package]]
 name = "cexpr"
@@ -990,9 +990,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
@@ -1724,7 +1724,7 @@ dependencies = [
 [[package]]
 name = "ring"
 version = "0.17.8"
-source = "git+https://github.com/coliasgroup/ring.git?rev=0e644b7837cffcd53a3ff67d7f478801b4e9e0ed#0e644b7837cffcd53a3ff67d7f478801b4e9e0ed"
+source = "git+https://github.com/coliasgroup/ring.git?rev=c5880ee6ae56bb684f5bb2499f1c05cef8943745#c5880ee6ae56bb684f5bb2499f1c05cef8943745"
 dependencies = [
  "cc",
  "cfg-if",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -24,9 +24,9 @@
     members = lib.naturalSort (lib.mapAttrsToList (_: v: v.path) localCrates);
   };
   patch.crates-io = {
-    ring = {
+    ring = localCrates.ring or  {
       git = "https://github.com/coliasgroup/ring.git";
-      rev = "0e644b7837cffcd53a3ff67d7f478801b4e9e0ed";
+      rev = "c5880ee6ae56bb684f5bb2499f1c05cef8943745"; # branch sel4
     };
   };
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,4 +148,4 @@ members = [
 
 [patch.crates-io.ring]
 git = "https://github.com/coliasgroup/ring.git"
-rev = "0e644b7837cffcd53a3ff67d7f478801b4e9e0ed"
+rev = "c5880ee6ae56bb684f5bb2499f1c05cef8943745"

--- a/crates/examples/microkit/http-server/pds/server/Cargo.nix
+++ b/crates/examples/microkit/http-server/pds/server/Cargo.nix
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-{ mk, localCrates, versions, serdeWith, smoltcpWith, ringWith }:
+{ mk, localCrates, versions, serdeWith, smoltcpWith }:
 
 mk {
   package.name = "microkit-http-server-example-server";

--- a/crates/sel4-async/network/rustls/utils/Cargo.toml
+++ b/crates/sel4-async/network/rustls/utils/Cargo.toml
@@ -19,6 +19,9 @@ license = "BSD-2-Clause"
 [dependencies]
 getrandom = { version = "0.2.10", features = ["custom"] }
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
-ring = { version = "=0.17.8", features = ["less-safe-getrandom-custom-or-rdrand"] }
 rustls = { version = "0.23.5", default-features = false, features = ["logging", "ring", "tls12"] }
 sel4-async-time = { path = "../../../time" }
+
+[dependencies.ring]
+version = "=0.17.8"
+features = ["less-safe-getrandom-custom-or-rdrand", "less-correct-none-os-has-linux-abi"]

--- a/hacking/cargo-manifest-management/manifest-scope.nix
+++ b/hacking/cargo-manifest-management/manifest-scope.nix
@@ -196,7 +196,10 @@ in rec {
 
   ringWith = features: {
     version = "=0.17.8";
-    features = [ "less-safe-getrandom-custom-or-rdrand" ] ++ features;
+    features = [
+      "less-safe-getrandom-custom-or-rdrand"
+      "less-correct-none-os-has-linux-abi"
+    ] ++ features;
   };
 
   rustlsWith = features: {

--- a/hacking/nix/scope/world/instances/default.nix
+++ b/hacking/nix/scope/world/instances/default.nix
@@ -92,7 +92,6 @@ in rec {
     tests.root-task.verus
     tests.root-task.dafny
     tests.root-task.default-test-harness
-    # tests.root-task.ring
     tests.capdl.threads
     tests.capdl.utcover
     microkit.examples.hello
@@ -105,6 +104,8 @@ in rec {
     examples.root-task.spawn-thread
     examples.root-task.spawn-task
     examples.root-task.serial-device
+
+    # tests.root-task.ring
   ];
 
   allAutomationScripts = map
@@ -237,6 +238,7 @@ in rec {
         };
       });
 
+      # ring at 8c665d20ed7621b81d8f4ad564cb7f43a02d42ad (sel4-testing)
       ring = maybe (haveFullRuntime && haveUnwindingSupport && !hostPlatform.isRiscV32 && !hostPlatform.isx86) (
         let
           rootTask = lib.makeOverridable mkTask {
@@ -245,6 +247,7 @@ in rec {
             justBuildTests = true;
             features = [
               "less-safe-getrandom-custom-or-rdrand"
+              "less-correct-none-os-has-linux-abi"
               # "slow_tests"
             ];
             release = true;

--- a/hacking/nix/scope/world/shell.nix
+++ b/hacking/nix/scope/world/shell.nix
@@ -31,8 +31,8 @@ let
   };
 
   capdlEnvVars = lib.optionalAttrs (!worldConfig.isMicrokit) {
-    CAPDL_SPEC_FILE = serializeCapDLSpec { inherit (dummyCapDLSpec.passthru) spec; };
-    CAPDL_FILL_DIR = dummyCapDLSpec.passthru.fill;
+    CAPDL_SPEC_FILE = serializeCapDLSpec { inherit (dummyCapDLSpec) cdl; };
+    CAPDL_FILL_DIR = dummyCapDLSpec.fill;
   };
 
   libcDir = "${stdenv.cc.libc}/${hostPlatform.config}";


### PR DESCRIPTION
Simplify the `os = "none"` enabling patch while we wait for https://github.com/briansmith/ring/pull/1937 to land.