### PR TITLE
nix: Use Microkit 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Microkit](https://github.com/seL4/microkit). In particular, this project works w
 following versions of those related projects:
 
 - seL4, when used without Microkit:
-  [`2249143c73b04c3a0d6d9ecf4055e0c6245772ab`](https://github.com/seL4/seL4/tree/2249143c73b04c3a0d6d9ecf4055e0c6245772ab)
+  [`cd6d3b8c25d49be2b100b0608cf0613483a6fffa`](https://github.com/seL4/seL4/tree/cd6d3b8c25d49be2b100b0608cf0613483a6fffa)
   (version 13.0.0, on [github.com/seL4/seL4:master](https://github.com/seL4/seL4/tree/master))
 - seL4, when used with Microkit:
   [`0cdbffec9cf6b4c7c9c57971cbee5a24a70c8fd0`](https://github.com/seL4/seL4/tree/0cdbffec9cf6b4c7c9c57971cbee5a24a70c8fd0)

--- a/hacking/nix/scope/sources.nix
+++ b/hacking/nix/scope/sources.nix
@@ -62,7 +62,7 @@ in rec {
 
   microkit = fetchGit {
     url = "https://github.com/coliasgroup/microkit.git";
-    rev = "de2bf9ac203d23b49e16c2079df01a203a8a21bf"; # branch "rust-nix"
+    rev = "1ccdfcb3b224533c965fd6508de3dd56657f959c"; # branch "rust-nix"
     local = localRoot + "/microkit";
   };
 


### PR DESCRIPTION
https://github.com/seL4/rust-sel4/pull/159 mistakenly used the first 1.3.0-dev commit.