### PR TITLE
crates/sel4-shared-ring-buffer/smoltcp: Add `can_{receive,transmit}`

### DIFF
--- a/crates/sel4-shared-ring-buffer/smoltcp/src/inner.rs
+++ b/crates/sel4-shared-ring-buffer/smoltcp/src/inner.rs
@@ -173,8 +173,16 @@ impl<A: AbstractBounceBufferAllocator> Inner<A> {
         Ok(notify_rx || notify_tx)
     }
 
+    pub(crate) fn can_receive(&mut self) -> bool {
+        self.can_claim_rx_buffer() && self.can_claim_tx_buffer()
+    }
+
+    pub(crate) fn can_transmit(&mut self) -> bool {
+        self.can_claim_tx_buffer()
+    }
+
     pub(crate) fn receive(&mut self) -> Option<(RxBufferIndex, TxBufferIndex)> {
-        if self.can_claim_rx_buffer() && self.can_claim_tx_buffer() {
+        if self.can_receive() {
             let rx = self.claim_rx_buffer().unwrap();
             let tx = self.claim_tx_buffer().unwrap();
             Some((rx, tx))

--- a/crates/sel4-shared-ring-buffer/smoltcp/src/lib.rs
+++ b/crates/sel4-shared-ring-buffer/smoltcp/src/lib.rs
@@ -66,6 +66,14 @@ impl<A: AbstractBounceBufferAllocator> DeviceImpl<A> {
         self.inner().borrow_mut().poll().unwrap()
     }
 
+    pub fn can_receive(&self) -> bool {
+        self.inner().borrow_mut().can_receive()
+    }
+
+    pub fn can_transmit(&self) -> bool {
+        self.inner().borrow_mut().can_transmit()
+    }
+
     fn new_rx_token(&self, rx_buffer: RxBufferIndex) -> RxToken<A> {
         RxToken {
             buffer: rx_buffer,


### PR DESCRIPTION
Useful for checking whether packets are available without popping them.