### PR TITLE
nix: Make `buildSysroot` more broadly useful

### DIFF
--- a/hacking/nix/rust-utils/build-sysroot.nix
+++ b/hacking/nix/rust-utils/build-sysroot.nix
@@ -18,6 +18,7 @@
 , std ? false
 , compilerBuiltinsMem ? true
 , compilerBuiltinsC ? rustEnvironment.compilerRTSource != null
+, src ? null
 , extraManifest ? {}
 , extraConfig ? {}
 }:
@@ -89,6 +90,9 @@ in
 } // lib.optionalAttrs compilerBuiltinsC {
   "CC_${targetTriple.name}" = "${stdenv.cc.targetPrefix}gcc";
   RUST_COMPILER_RT_ROOT = rustEnvironment.compilerRTSource;
+} // lib.optionalAttrs (src != null) {
+  # HACK
+  __CARGO_TESTS_ONLY_SRC_ROOT = src;
 }) ''
   cargo build \
     -Z unstable-options \

--- a/hacking/nix/rust-utils/build-sysroot.nix
+++ b/hacking/nix/rust-utils/build-sysroot.nix
@@ -36,7 +36,7 @@ let
   manifest = crateUtils.toTOMLFile "Cargo.toml" (crateUtils.clobber [
     {
       inherit package;
-      lib.path = crateUtils.dummyLibInSrc;
+      lib.path = crateUtils.dummyLibWithoutStdInSrc;
     }
     extraManifest
   ]);

--- a/hacking/nix/rust-utils/crate-utils.nix
+++ b/hacking/nix/rust-utils/crate-utils.nix
@@ -26,6 +26,7 @@ rec {
   ###
 
   dummyLibInSrc = dummyInSrc "lib.rs" dummyLib;
+  dummyLibWithoutStdInSrc = dummyInSrc "lib.rs" dummyLibWithoutStd;
   dummyMainWithStdInSrc = dummyInSrc "main.rs" dummyMainWithStd;
   dummyMainWithOrWithoutStdInSrc = dummyInSrc "main.rs" dummyMainWithOrWithoutStd;
 
@@ -39,13 +40,13 @@ rec {
     in
       "${src}/${name}";
 
+  dummyLibWithoutStd = writeText "lib.rs" ''
+    #![no_std]
+  '';
+
   dummyMainWithStd = writeText "main.rs" ''
     fn main() {}
   '';
-
-  # dummyLib = writeText "lib.rs" ''
-  #   #![no_std]
-  # '';
 
   # HACK for cargo test (required by harness = "false")
   dummyLib = dummyMainOrLibWithOrWithoutStd;

--- a/hacking/nix/scope/world/shell.nix
+++ b/hacking/nix/scope/world/shell.nix
@@ -83,7 +83,8 @@ mkShell (seL4RustEnvVars // kernelLoaderConfigEnvVars // capdlEnvVars // bindgen
   ];
 
   shellHook = ''
-    # abbreviation
     export h=$HOST_CARGO_FLAGS
+    export t="--target $RUST_SEL4_TARGET"
+    export bt="--target $RUST_BARE_METAL_TARGET"
   '';
 })


### PR DESCRIPTION
- Fix build for native targets
- Allow specifying alternative rustc source using the Cargo `__CARGO_TESTS_ONLY_SRC_ROOT` hack