### PR TITLE
irq_control_get_trigger: change trigger to bool

### DIFF
--- a/crates/sel4-capdl-initializer/core/src/lib.rs
+++ b/crates/sel4-capdl-initializer/core/src/lib.rs
@@ -336,13 +336,13 @@ impl<'a, N: ObjectName, D: Content, M: GetEmbeddedFrame, B: BorrowMut<[PerObject
                                 if #[sel4_cfg(MAX_NUM_NODES = "1")] {
                                     init_thread::slot::IRQ_CONTROL.cap().irq_control_get_trigger(
                                         *irq,
-                                        obj.extra.trigger,
+                                        obj.extra.trigger != 0,
                                         &cslot_to_relative_cptr(slot),
                                     )?;
                                 } else {
                                     init_thread::slot::IRQ_CONTROL.cap().irq_control_get_trigger_core(
                                         *irq,
-                                        obj.extra.trigger,
+                                        obj.extra.trigger != 0,
                                         obj.extra.target,
                                         &cslot_to_relative_cptr(slot),
                                     )?;

--- a/crates/sel4/src/arch/arm/invocations.rs
+++ b/crates/sel4/src/arch/arm/invocations.rs
@@ -145,7 +145,7 @@ impl<C: InvocationContext> IrqControl<C> {
     pub fn irq_control_get_trigger_core(
         self,
         irq: Word,
-        trigger: Word,
+        edge_triggered: bool,
         target: Word,
         dst: &AbsoluteCPtr,
     ) -> Result<()> {
@@ -153,7 +153,7 @@ impl<C: InvocationContext> IrqControl<C> {
             ipc_buffer.inner_mut().seL4_IRQControl_GetTriggerCore(
                 cptr.bits(),
                 irq,
-                trigger,
+                edge_triggered.into(),
                 dst.root().bits(),
                 dst.path().bits(),
                 dst.path().depth_for_kernel(),
@@ -166,14 +166,14 @@ impl<C: InvocationContext> IrqControl<C> {
     pub fn irq_control_get_trigger(
         self,
         irq: Word,
-        trigger: Word,
+        edge_triggered: bool,
         dst: &AbsoluteCPtr,
     ) -> Result<()> {
         Error::wrap(self.invoke(|cptr, ipc_buffer| {
             ipc_buffer.inner_mut().seL4_IRQControl_GetTrigger(
                 cptr.bits(),
                 irq,
-                trigger,
+                edge_triggered.into(),
                 dst.root().bits(),
                 dst.path().bits(),
                 dst.path().depth_for_kernel(),


### PR DESCRIPTION
The kernel only expects 0 (level-triggered) or 1 (edge-triggered) for the trigger argument in  irq_control_get_trigger and irq_control_get_trigger_core. As such, it makes more sense for the client-facing interface to accept a bool for the trigger argument.