### PR TITLE
Suppress warnings in macro expansions

### DIFF
--- a/crates/sel4-root-task/src/entry.rs
+++ b/crates/sel4-root-task/src/entry.rs
@@ -50,6 +50,7 @@ extern "Rust" {
 #[macro_export]
 macro_rules! declare_main {
     ($main:expr) => {
+        #[allow(non_snake_case)]
         #[no_mangle]
         fn __sel4_root_task__main(bootinfo: &$crate::_private::BootInfoPtr) -> ! {
             $crate::_private::run_main($main, bootinfo);

--- a/crates/sel4-runtime-common/src/start.rs
+++ b/crates/sel4-runtime-common/src/start.rs
@@ -12,6 +12,7 @@ use core::arch::global_asm;
 #[macro_export]
 macro_rules! declare_stack {
     ($size:expr) => {
+        #[allow(non_upper_case_globals)]
         #[no_mangle]
         static __sel4_runtime_common__stack_bottom: $crate::_private::start::StackBottom = {
             static STACK: $crate::_private::start::Stack<{ $size }> =


### PR DESCRIPTION
To avoid warning from rust-analyzer.