### PR TITLE
Remove metadata from target specs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,6 +2276,7 @@ name = "sel4-generate-target-specs"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "rustc_version",
  "serde_json",
 ]
 

--- a/crates/sel4-generate-target-specs/Cargo.nix
+++ b/crates/sel4-generate-target-specs/Cargo.nix
@@ -11,4 +11,7 @@ mk {
   dependencies = {
     inherit (versions) serde_json clap;
   };
+  build-dependencies = {
+    inherit (versions) rustc_version;
+  };
 }

--- a/crates/sel4-generate-target-specs/Cargo.toml
+++ b/crates/sel4-generate-target-specs/Cargo.toml
@@ -19,3 +19,6 @@ license = "BSD-2-Clause"
 [dependencies]
 clap = "4.4.6"
 serde_json = "1.0.87"
+
+[build-dependencies]
+rustc_version = "0.4.0"

--- a/crates/sel4-generate-target-specs/build.rs
+++ b/crates/sel4-generate-target-specs/build.rs
@@ -1,0 +1,31 @@
+//
+// Copyright 2024, Colias Group, LLC
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+
+use core::cmp::Reverse;
+
+// Determine whether rustc includes https://github.com/rust-lang/rust/pull/122305
+
+fn main() {
+    let key = {
+        let version_meta = rustc_version::version_meta().unwrap();
+        let semver = version_meta.semver;
+        let commit_date = order_date(version_meta.commit_date);
+        (semver.major, semver.minor, semver.patch, commit_date)
+    };
+    let check_cfg_required = (1, 80, 0, order_date(Some("2024-05-05".to_owned())));
+    let target_spec_has_metadata = (1, 78, 0, order_date(Some("2024-03-15".to_owned())));
+    if key >= check_cfg_required {
+        println!("cargo:rustc-check-cfg=cfg(target_spec_has_metadata)");
+    }
+    if key >= target_spec_has_metadata {
+        println!("cargo:rustc-cfg=target_spec_has_metadata");
+    }
+}
+
+// no build date means more recent
+fn order_date(date: Option<String>) -> Reverse<Option<Reverse<String>>> {
+    Reverse(date.map(Reverse))
+}

--- a/crates/sel4-generate-target-specs/src/main.rs
+++ b/crates/sel4-generate-target-specs/src/main.rs
@@ -223,7 +223,12 @@ impl Context {
 }
 
 fn builtin(triple: &str) -> Target {
-    Target::expect_builtin(&TargetTriple::from_triple(triple))
+    let mut target = Target::expect_builtin(&TargetTriple::from_triple(triple));
+    #[cfg(target_spec_has_metadata)]
+    {
+        target.metadata = Default::default();
+    }
+    target
 }
 
 fn all_target_specs() -> BTreeMap<String, Target> {

--- a/support/targets/aarch64-sel4-microkit-minimal.json
+++ b/support/targets/aarch64-sel4-microkit-minimal.json
@@ -13,10 +13,10 @@
   "llvm-target": "aarch64-unknown-none",
   "max-atomic-width": 128,
   "metadata": {
-    "description": "Bare ARM64, hardfloat",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "panic-strategy": "abort",
   "pre-link-args": {

--- a/support/targets/aarch64-sel4-microkit-resettable-minimal.json
+++ b/support/targets/aarch64-sel4-microkit-resettable-minimal.json
@@ -13,10 +13,10 @@
   "llvm-target": "aarch64-unknown-none",
   "max-atomic-width": 128,
   "metadata": {
-    "description": "Bare ARM64, hardfloat",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "panic-strategy": "abort",
   "pre-link-args": {

--- a/support/targets/aarch64-sel4-microkit-resettable.json
+++ b/support/targets/aarch64-sel4-microkit-resettable.json
@@ -13,10 +13,10 @@
   "llvm-target": "aarch64-unknown-none",
   "max-atomic-width": 128,
   "metadata": {
-    "description": "Bare ARM64, hardfloat",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "pre-link-args": {
     "gnu-lld": [

--- a/support/targets/aarch64-sel4-microkit.json
+++ b/support/targets/aarch64-sel4-microkit.json
@@ -13,10 +13,10 @@
   "llvm-target": "aarch64-unknown-none",
   "max-atomic-width": 128,
   "metadata": {
-    "description": "Bare ARM64, hardfloat",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "pre-link-args": {
     "gnu-lld": [

--- a/support/targets/aarch64-sel4-minimal.json
+++ b/support/targets/aarch64-sel4-minimal.json
@@ -12,10 +12,10 @@
   "llvm-target": "aarch64-unknown-none",
   "max-atomic-width": 128,
   "metadata": {
-    "description": "Bare ARM64, hardfloat",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "panic-strategy": "abort",
   "pre-link-args": {

--- a/support/targets/aarch64-sel4.json
+++ b/support/targets/aarch64-sel4.json
@@ -12,10 +12,10 @@
   "llvm-target": "aarch64-unknown-none",
   "max-atomic-width": 128,
   "metadata": {
-    "description": "Bare ARM64, hardfloat",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "pre-link-args": {
     "gnu-lld": [

--- a/support/targets/armv7a-sel4-minimal.json
+++ b/support/targets/armv7a-sel4-minimal.json
@@ -15,10 +15,10 @@
   "llvm-target": "armv7a-none-eabi",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Bare Armv7-A",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "panic-strategy": "abort",
   "relocation-model": "static",

--- a/support/targets/armv7a-sel4.json
+++ b/support/targets/armv7a-sel4.json
@@ -15,10 +15,10 @@
   "llvm-target": "armv7a-none-eabi",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Bare Armv7-A",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "panic-strategy": "abort",
   "relocation-model": "static",

--- a/support/targets/riscv32imac-sel4-minimal.json
+++ b/support/targets/riscv32imac-sel4-minimal.json
@@ -13,10 +13,10 @@
   "llvm-target": "riscv32",
   "max-atomic-width": 32,
   "metadata": {
-    "description": "Bare RISC-V (RV32IMAC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "panic-strategy": "abort",
   "relocation-model": "static",

--- a/support/targets/riscv32imac-sel4.json
+++ b/support/targets/riscv32imac-sel4.json
@@ -13,10 +13,10 @@
   "llvm-target": "riscv32",
   "max-atomic-width": 32,
   "metadata": {
-    "description": "Bare RISC-V (RV32IMAC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "relocation-model": "static",
   "target-pointer-width": "32"

--- a/support/targets/riscv32imafc-sel4-minimal.json
+++ b/support/targets/riscv32imafc-sel4-minimal.json
@@ -14,10 +14,10 @@
   "llvm-target": "riscv32",
   "max-atomic-width": 32,
   "metadata": {
-    "description": "Bare RISC-V (RV32IMAFC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "panic-strategy": "abort",
   "relocation-model": "static",

--- a/support/targets/riscv32imafc-sel4.json
+++ b/support/targets/riscv32imafc-sel4.json
@@ -14,10 +14,10 @@
   "llvm-target": "riscv32",
   "max-atomic-width": 32,
   "metadata": {
-    "description": "Bare RISC-V (RV32IMAFC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "relocation-model": "static",
   "target-pointer-width": "32"

--- a/support/targets/riscv64gc-sel4-microkit-minimal.json
+++ b/support/targets/riscv64gc-sel4-microkit-minimal.json
@@ -16,10 +16,10 @@
   "llvm-target": "riscv64",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Bare RISC-V (RV64IMAFDC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "panic-strategy": "abort",
   "relocation-model": "static",

--- a/support/targets/riscv64gc-sel4-microkit-resettable-minimal.json
+++ b/support/targets/riscv64gc-sel4-microkit-resettable-minimal.json
@@ -16,10 +16,10 @@
   "llvm-target": "riscv64",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Bare RISC-V (RV64IMAFDC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "panic-strategy": "abort",
   "relocation-model": "static",

--- a/support/targets/riscv64gc-sel4-microkit-resettable.json
+++ b/support/targets/riscv64gc-sel4-microkit-resettable.json
@@ -16,10 +16,10 @@
   "llvm-target": "riscv64",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Bare RISC-V (RV64IMAFDC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "relocation-model": "static",
   "supported-sanitizers": [

--- a/support/targets/riscv64gc-sel4-microkit.json
+++ b/support/targets/riscv64gc-sel4-microkit.json
@@ -16,10 +16,10 @@
   "llvm-target": "riscv64",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Bare RISC-V (RV64IMAFDC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "relocation-model": "static",
   "supported-sanitizers": [

--- a/support/targets/riscv64gc-sel4-minimal.json
+++ b/support/targets/riscv64gc-sel4-minimal.json
@@ -15,10 +15,10 @@
   "llvm-target": "riscv64",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Bare RISC-V (RV64IMAFDC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "panic-strategy": "abort",
   "relocation-model": "static",

--- a/support/targets/riscv64gc-sel4.json
+++ b/support/targets/riscv64gc-sel4.json
@@ -15,10 +15,10 @@
   "llvm-target": "riscv64",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Bare RISC-V (RV64IMAFDC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "relocation-model": "static",
   "supported-sanitizers": [

--- a/support/targets/riscv64imac-sel4-microkit-minimal.json
+++ b/support/targets/riscv64imac-sel4-microkit-minimal.json
@@ -15,10 +15,10 @@
   "llvm-target": "riscv64",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Bare RISC-V (RV64IMAC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "panic-strategy": "abort",
   "relocation-model": "static",

--- a/support/targets/riscv64imac-sel4-microkit-resettable-minimal.json
+++ b/support/targets/riscv64imac-sel4-microkit-resettable-minimal.json
@@ -15,10 +15,10 @@
   "llvm-target": "riscv64",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Bare RISC-V (RV64IMAC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "panic-strategy": "abort",
   "relocation-model": "static",

--- a/support/targets/riscv64imac-sel4-microkit-resettable.json
+++ b/support/targets/riscv64imac-sel4-microkit-resettable.json
@@ -15,10 +15,10 @@
   "llvm-target": "riscv64",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Bare RISC-V (RV64IMAC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "relocation-model": "static",
   "supported-sanitizers": [

--- a/support/targets/riscv64imac-sel4-microkit.json
+++ b/support/targets/riscv64imac-sel4-microkit.json
@@ -15,10 +15,10 @@
   "llvm-target": "riscv64",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Bare RISC-V (RV64IMAC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "relocation-model": "static",
   "supported-sanitizers": [

--- a/support/targets/riscv64imac-sel4-minimal.json
+++ b/support/targets/riscv64imac-sel4-minimal.json
@@ -14,10 +14,10 @@
   "llvm-target": "riscv64",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Bare RISC-V (RV64IMAC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "panic-strategy": "abort",
   "relocation-model": "static",

--- a/support/targets/riscv64imac-sel4.json
+++ b/support/targets/riscv64imac-sel4.json
@@ -14,10 +14,10 @@
   "llvm-target": "riscv64",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Bare RISC-V (RV64IMAC ISA)",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "relocation-model": "static",
   "supported-sanitizers": [

--- a/support/targets/x86_64-sel4-minimal.json
+++ b/support/targets/x86_64-sel4-minimal.json
@@ -14,10 +14,10 @@
   "llvm-target": "x86_64-unknown-none-elf",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Freestanding/bare-metal x86_64 softfloat",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "panic-strategy": "abort",
   "plt-by-default": false,

--- a/support/targets/x86_64-sel4.json
+++ b/support/targets/x86_64-sel4.json
@@ -14,10 +14,10 @@
   "llvm-target": "x86_64-unknown-none-elf",
   "max-atomic-width": 64,
   "metadata": {
-    "description": "Freestanding/bare-metal x86_64 softfloat",
-    "host_tools": false,
-    "std": false,
-    "tier": 2
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
   },
   "plt-by-default": false,
   "relro-level": "full",


### PR DESCRIPTION
This metadata was leftover from the builtin targets they are based on.