### PR TITLE
Fix stack overflow during unwinding for some default configurations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "7b9d03130b08257bc8110b0df827d8b137fdf67a95e2459eaace2e13fecf1d72"
 dependencies = [
  "cpp_demangle",
  "fallible-iterator 0.3.0",
- "gimli 0.30.0",
+ "gimli",
  "rustc-demangle",
  "smallvec",
 ]
@@ -797,12 +797,6 @@ dependencies = [
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "gimli"
@@ -1977,7 +1971,7 @@ name = "sel4-backtrace-addr2line-context-helper"
 version = "0.1.0"
 dependencies = [
  "addr2line",
- "gimli 0.30.0",
+ "gimli",
  "object",
  "stable_deref_trait",
 ]
@@ -3353,11 +3347,11 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "unwinding"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf10020069685fe1046038e07aec0b92b087ed282aa620c9afd9671b7f26ce9d"
+checksum = "dc55842d0db6329a669d55a623c674b02d677b16bfb2d24857d4089d41eba882"
 dependencies = [
- "gimli 0.26.2",
+ "gimli",
 ]
 
 [[package]]

--- a/crates/private/tests/root-task/panicking/src/main.rs
+++ b/crates/private/tests/root-task/panicking/src/main.rs
@@ -13,7 +13,7 @@ use sel4_root_task::{debug_println, panicking, root_task};
 
 static F1_DROPPED: AtomicBool = AtomicBool::new(false);
 
-#[root_task(stack_size = 4096 * 64, heap_size = 4096 * 16)] // TODO decrease stack size
+#[root_task(heap_size = 4096 * 16)]
 fn main(_: &sel4::BootInfoPtr) -> ! {
     let _ = panicking::catch_unwind(|| {
         f1();

--- a/crates/sel4-backtrace/Cargo.toml
+++ b/crates/sel4-backtrace/Cargo.toml
@@ -29,7 +29,7 @@ sel4-backtrace-types = { path = "types" }
 serde = { version = "1.0.147", default-features = false, optional = true }
 
 [dependencies.unwinding]
-version = "0.1.6"
+version = "0.2.1"
 default-features = false
 features = ["unwinder", "fde-custom", "hide-trace"]
 optional = true

--- a/crates/sel4-backtrace/src/lib.rs
+++ b/crates/sel4-backtrace/src/lib.rs
@@ -27,7 +27,7 @@ cfg_if::cfg_if! {
             }
 
             extern "C" fn callback<F1: FnMut(Entry) -> Result<(), E1>, E1>(
-                unwind_ctx: &mut UnwindContext,
+                unwind_ctx: &UnwindContext,
                 arg: *mut c_void,
             ) -> UnwindReasonCode {
                 let data = unsafe { &mut *(arg as *mut CallbackData<F1>) };

--- a/crates/sel4-generate-target-specs/Cargo.nix
+++ b/crates/sel4-generate-target-specs/Cargo.nix
@@ -14,4 +14,7 @@ mk {
   build-dependencies = {
     inherit (versions) rustc_version;
   };
+  package.metadata.rust-analyzer = {
+    rustc_private = true;
+  };
 }

--- a/crates/sel4-generate-target-specs/Cargo.toml
+++ b/crates/sel4-generate-target-specs/Cargo.toml
@@ -16,6 +16,9 @@ authors = ["Nick Spinale <nick.spinale@coliasgroup.com>"]
 edition = "2021"
 license = "BSD-2-Clause"
 
+[package.metadata.rust-analyzer]
+rustc_private = true
+
 [dependencies]
 clap = "4.4.6"
 serde_json = "1.0.87"

--- a/crates/sel4-generate-target-specs/src/main.rs
+++ b/crates/sel4-generate-target-specs/src/main.rs
@@ -223,6 +223,7 @@ impl Context {
 }
 
 fn builtin(triple: &str) -> Target {
+    #[cfg_attr(not(target_spec_has_metadata), allow(unused_mut))]
     let mut target = Target::expect_builtin(&TargetTriple::from_triple(triple));
     #[cfg(target_spec_has_metadata)]
     {

--- a/crates/sel4-microkit/src/lib.rs
+++ b/crates/sel4-microkit/src/lib.rs
@@ -83,7 +83,12 @@ macro_rules! declare_protection_domain {
 }
 
 #[doc(hidden)]
-pub const DEFAULT_STACK_SIZE: usize = 0x10000;
+pub const DEFAULT_STACK_SIZE: usize = 1024
+    * if cfg!(panic = "unwind") && cfg!(debug_assertions) {
+        128
+    } else {
+        64
+    };
 
 // For macros
 #[doc(hidden)]

--- a/crates/sel4-panicking/Cargo.toml
+++ b/crates/sel4-panicking/Cargo.toml
@@ -28,7 +28,7 @@ sel4-panicking-env = { path = "env" }
 rustc_version = "0.4.0"
 
 [target."cfg(not(target_arch = \"arm\"))".dependencies.unwinding]
-version = "0.1.6"
+version = "0.2.1"
 default-features = false
 features = ["unwinder", "fde-custom", "hide-trace", "personality"]
 optional = true

--- a/crates/sel4-root-task/src/lib.rs
+++ b/crates/sel4-root-task/src/lib.rs
@@ -56,7 +56,12 @@ macro_rules! declare_root_task {
 }
 
 #[doc(hidden)]
-pub const DEFAULT_STACK_SIZE: usize = 0x10000;
+pub const DEFAULT_STACK_SIZE: usize = 1024
+    * if cfg!(panic = "unwind") && cfg!(debug_assertions) {
+        128
+    } else {
+        64
+    };
 
 // For macros
 #[doc(hidden)]

--- a/crates/sel4-runtime-common/Cargo.toml
+++ b/crates/sel4-runtime-common/Cargo.toml
@@ -29,7 +29,7 @@ sel4-panicking-env = { path = "../sel4-panicking/env" }
 sel4-stack = { path = "../sel4-stack" }
 
 [target."cfg(not(target_arch = \"arm\"))".dependencies.unwinding]
-version = "0.1.6"
+version = "0.2.1"
 default-features = false
 features = ["unwinder", "fde-custom", "hide-trace"]
 optional = true

--- a/crates/sel4-runtime-common/src/unwinding.rs
+++ b/crates/sel4-runtime-common/src/unwinding.rs
@@ -37,7 +37,7 @@ unsafe impl EhFrameFinder for EhFrameFinderImpl {
         })?;
 
         Some(FrameInfo {
-            text_base,
+            text_base: Some(text_base),
             kind: FrameInfoKind::EhFrameHdr(eh_frame_hdr),
         })
     }

--- a/hacking/cargo-manifest-management/manifest-scope.nix
+++ b/hacking/cargo-manifest-management/manifest-scope.nix
@@ -124,7 +124,7 @@ in rec {
     synstructure = "0.12.6";
     thiserror = "1.0";
     tock-registers = "0.8.1";
-    unwinding = "0.1.6";
+    unwinding = "0.2.1";
     virtio-drivers = "0.7.2";
     webpki-roots = "0.26";
     zerocopy = "0.7.32";

--- a/hacking/nix/scope/plat-utils/qemu/automate_simple.py
+++ b/hacking/nix/scope/plat-utils/qemu/automate_simple.py
@@ -18,14 +18,17 @@ def main():
 def run(args):
     child = pexpect.spawn(args.simulate, encoding='utf-8')
     child.logfile = sys.stdout
-    ix = child.expect(['TEST_PASS', 'TEST_FAIL', pexpect.TIMEOUT], timeout=args.timeout)
-    print()
-    if ix != 0:
-        if ix == 1:
-            sys.exit('> test reported failure')
-        if ix == 2:
-            sys.exit('> test timed out')
-        assert False
+    try:
+        ix = child.expect(['TEST_PASS', 'TEST_FAIL', pexpect.TIMEOUT], timeout=args.timeout)
+        print()
+        if ix != 0:
+            if ix == 1:
+                sys.exit('> test reported failure')
+            if ix == 2:
+                sys.exit('> test timed out')
+            assert False
+    except KeyboardInterrupt:
+        sys.exit('> interrupted')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
In cases where `panic = "unwind"` and optimizations are disabled, unwinding seems to require a surprising amount of memory (> 64K). This should be investigated further (https://github.com/seL4/rust-sel4/issues/201). For now, I've just increased the default stack size for these particular cases.