### PR TITLE
Expose some items in rustdoc

### DIFF
--- a/crates/sel4-microkit/src/lib.rs
+++ b/crates/sel4-microkit/src/lib.rs
@@ -82,7 +82,6 @@ macro_rules! declare_protection_domain {
     };
 }
 
-#[doc(hidden)]
 pub const DEFAULT_STACK_SIZE: usize = 1024
     * if cfg!(panic = "unwind") && cfg!(debug_assertions) {
         128

--- a/crates/sel4-panicking/src/lib.rs
+++ b/crates/sel4-panicking/src/lib.rs
@@ -22,7 +22,7 @@ use core::panic::Location;
 use core::panic::{PanicInfo, UnwindSafe};
 
 #[cfg(panic_info_message_stable)]
-use core::panic::PanicMessage;
+pub use core::panic::PanicMessage;
 
 use cfg_if::cfg_if;
 
@@ -42,7 +42,7 @@ pub use hook::{set_hook, PanicHook};
 pub use payload::{Payload, SmallPayload, UpcastIntoPayload, SMALL_PAYLOAD_MAX_SIZE};
 
 #[cfg(not(panic_info_message_stable))]
-type PanicMessage<'a> = &'a fmt::Arguments<'a>;
+pub type PanicMessage<'a> = &'a fmt::Arguments<'a>;
 
 pub struct ExternalPanicInfo<'a> {
     payload: Payload,

--- a/crates/sel4-root-task/src/lib.rs
+++ b/crates/sel4-root-task/src/lib.rs
@@ -55,7 +55,6 @@ macro_rules! declare_root_task {
     };
 }
 
-#[doc(hidden)]
 pub const DEFAULT_STACK_SIZE: usize = 1024
     * if cfg!(panic = "unwind") && cfg!(debug_assertions) {
         128


### PR DESCRIPTION
Expose `sel4_panicking::PanicMessage` and `{sel4_root_task,sel4_microkit}::DEFAULT_STACK_SIZE`.