### PR TITLE
Improve API clarity and docs

### DIFF
--- a/crates/examples/root-task/example-root-task-without-runtime/src/main.rs
+++ b/crates/examples/root-task/example-root-task-without-runtime/src/main.rs
@@ -37,7 +37,7 @@ fn main(bootinfo: &sel4::BootInfoPtr) -> sel4::Result<Never> {
 
     untyped.with(&mut ipc_buffer).untyped_retype(
         &blueprint,
-        &cnode.relative_self(),
+        &cnode.absolute_cptr_for_self(),
         unbadged_notification_slot.index(),
         1,
     )?;

--- a/crates/examples/root-task/example-root-task-without-runtime/src/main.rs
+++ b/crates/examples/root-task/example-root-task-without-runtime/src/main.rs
@@ -46,9 +46,9 @@ fn main(bootinfo: &sel4::BootInfoPtr) -> sel4::Result<Never> {
 
     cnode
         .with(&mut ipc_buffer)
-        .relative(badged_notification_slot.cptr())
+        .absolute_cptr(badged_notification_slot.cptr())
         .mint(
-            &cnode.relative(unbadged_notification_slot.cptr()),
+            &cnode.absolute_cptr(unbadged_notification_slot.cptr()),
             sel4::CapRights::write_only(),
             badge,
         )?;

--- a/crates/examples/root-task/example-root-task/src/main.rs
+++ b/crates/examples/root-task/example-root-task/src/main.rs
@@ -34,7 +34,7 @@ fn main(bootinfo: &sel4::BootInfoPtr) -> sel4::Result<Never> {
 
     untyped.untyped_retype(
         &blueprint,
-        &cnode.relative_self(),
+        &cnode.absolute_cptr_for_self(),
         unbadged_notification_slot.index(),
         1,
     )?;

--- a/crates/examples/root-task/example-root-task/src/main.rs
+++ b/crates/examples/root-task/example-root-task/src/main.rs
@@ -41,8 +41,8 @@ fn main(bootinfo: &sel4::BootInfoPtr) -> sel4::Result<Never> {
 
     let badge = 0x1337;
 
-    cnode.relative(badged_notification_slot.cptr()).mint(
-        &cnode.relative(unbadged_notification_slot.cptr()),
+    cnode.absolute_cptr(badged_notification_slot.cptr()).mint(
+        &cnode.absolute_cptr(unbadged_notification_slot.cptr()),
         sel4::CapRights::write_only(),
         badge,
     )?;

--- a/crates/examples/root-task/serial-device/src/main.rs
+++ b/crates/examples/root-task/serial-device/src/main.rs
@@ -190,9 +190,9 @@ fn trim_untyped(
 // // //
 
 #[repr(C, align(4096))]
-struct FreePagePlaceHolder(#[allow(dead_code)] [u8; GRANULE_SIZE]);
+struct FreePagePlaceholder(#[allow(dead_code)] [u8; GRANULE_SIZE]);
 
-static mut FREE_PAGE_PLACEHOLDER: FreePagePlaceHolder = FreePagePlaceHolder([0; GRANULE_SIZE]);
+static mut FREE_PAGE_PLACEHOLDER: FreePagePlaceholder = FreePagePlaceholder([0; GRANULE_SIZE]);
 
 fn init_free_page_addr(bootinfo: &sel4::BootInfo) -> usize {
     let addr = ptr::addr_of!(FREE_PAGE_PLACEHOLDER) as usize;

--- a/crates/examples/root-task/serial-device/src/main.rs
+++ b/crates/examples/root-task/serial-device/src/main.rs
@@ -53,7 +53,9 @@ fn main(bootinfo: &sel4::BootInfoPtr) -> sel4::Result<Never> {
     kernel_ut
         .untyped_retype(
             &sel4::ObjectBlueprint::Notification,
-            &sel4::init_thread::slot::CNODE.cap().relative_self(),
+            &sel4::init_thread::slot::CNODE
+                .cap()
+                .absolute_cptr_for_self(),
             irq_notification_slot.index(),
             1,
         )
@@ -95,7 +97,9 @@ fn main(bootinfo: &sel4::BootInfoPtr) -> sel4::Result<Never> {
     device_ut_cap
         .untyped_retype(
             &sel4::cap_type::Granule::object_blueprint(),
-            &sel4::init_thread::slot::CNODE.cap().relative_self(),
+            &sel4::init_thread::slot::CNODE
+                .cap()
+                .absolute_cptr_for_self(),
             serial_device_frame_slot.index(),
             1,
         )
@@ -170,7 +174,9 @@ fn trim_untyped(
         let size_bits = (target_paddr - cur_paddr).ilog2().try_into().unwrap();
         ut.untyped_retype(
             &sel4::ObjectBlueprint::Untyped { size_bits },
-            &sel4::init_thread::slot::CNODE.cap().relative_self(),
+            &sel4::init_thread::slot::CNODE
+                .cap()
+                .absolute_cptr_for_self(),
             free_slot_b.index(),
             1,
         )

--- a/crates/examples/root-task/serial-device/src/main.rs
+++ b/crates/examples/root-task/serial-device/src/main.rs
@@ -41,7 +41,7 @@ fn main(bootinfo: &sel4::BootInfoPtr) -> sel4::Result<Never> {
             SERIAL_DEVICE_IRQ.try_into().unwrap(),
             &sel4::init_thread::slot::CNODE
                 .cap()
-                .relative(irq_handler_cap),
+                .absolute_cptr(irq_handler_cap),
         )
         .unwrap();
 
@@ -165,10 +165,10 @@ fn trim_untyped(
 ) {
     let rel_a = sel4::init_thread::slot::CNODE
         .cap()
-        .relative(free_slot_a.cptr());
+        .absolute_cptr(free_slot_a.cptr());
     let rel_b = sel4::init_thread::slot::CNODE
         .cap()
-        .relative(free_slot_b.cptr());
+        .absolute_cptr(free_slot_b.cptr());
     let mut cur_paddr = ut_paddr;
     while cur_paddr != target_paddr {
         let size_bits = (target_paddr - cur_paddr).ilog2().try_into().unwrap();

--- a/crates/examples/root-task/spawn-task/src/main.rs
+++ b/crates/examples/root-task/spawn-task/src/main.rs
@@ -53,7 +53,7 @@ fn main(bootinfo: &sel4::BootInfoPtr) -> sel4::Result<Never> {
         .mint(
             &sel4::init_thread::slot::CNODE
                 .cap()
-                .relative(inter_task_nfn),
+                .absolute_cptr(inter_task_nfn),
             sel4::CapRights::write_only(),
             0,
         )
@@ -75,7 +75,9 @@ fn main(bootinfo: &sel4::BootInfoPtr) -> sel4::Result<Never> {
     child_cnode
         .absolute_cptr_from_bits_with_depth(2, child_cnode_size_bits)
         .mint(
-            &sel4::init_thread::slot::CNODE.cap().relative(child_tcb),
+            &sel4::init_thread::slot::CNODE
+                .cap()
+                .absolute_cptr(child_tcb),
             sel4::CapRights::all(),
             0,
         )

--- a/crates/examples/root-task/spawn-task/src/main.rs
+++ b/crates/examples/root-task/spawn-task/src/main.rs
@@ -49,7 +49,7 @@ fn main(bootinfo: &sel4::BootInfoPtr) -> sel4::Result<Never> {
         object_allocator.allocate_variable_sized::<sel4::cap_type::CNode>(child_cnode_size_bits);
 
     child_cnode
-        .relative_bits_with_depth(1, child_cnode_size_bits)
+        .absolute_cptr_from_bits_with_depth(1, child_cnode_size_bits)
         .mint(
             &sel4::init_thread::slot::CNODE
                 .cap()
@@ -73,7 +73,7 @@ fn main(bootinfo: &sel4::BootInfoPtr) -> sel4::Result<Never> {
         .unwrap();
 
     child_cnode
-        .relative_bits_with_depth(2, child_cnode_size_bits)
+        .absolute_cptr_from_bits_with_depth(2, child_cnode_size_bits)
         .mint(
             &sel4::init_thread::slot::CNODE.cap().relative(child_tcb),
             sel4::CapRights::all(),

--- a/crates/examples/root-task/spawn-task/src/main.rs
+++ b/crates/examples/root-task/spawn-task/src/main.rs
@@ -97,9 +97,9 @@ fn main(bootinfo: &sel4::BootInfoPtr) -> sel4::Result<Never> {
 // // //
 
 #[repr(C, align(4096))]
-struct FreePagePlaceHolder(#[allow(dead_code)] [u8; GRANULE_SIZE]);
+struct FreePagePlaceholder(#[allow(dead_code)] [u8; GRANULE_SIZE]);
 
-static mut FREE_PAGE_PLACEHOLDER: FreePagePlaceHolder = FreePagePlaceHolder([0; GRANULE_SIZE]);
+static mut FREE_PAGE_PLACEHOLDER: FreePagePlaceholder = FreePagePlaceholder([0; GRANULE_SIZE]);
 
 fn init_free_page_addr(bootinfo: &sel4::BootInfo) -> usize {
     let addr = ptr::addr_of!(FREE_PAGE_PLACEHOLDER) as usize;

--- a/crates/examples/root-task/spawn-task/src/object_allocator.rs
+++ b/crates/examples/root-task/spawn-task/src/object_allocator.rs
@@ -24,7 +24,9 @@ impl ObjectAllocator {
         self.ut
             .untyped_retype(
                 &blueprint,
-                &sel4::init_thread::slot::CNODE.cap().relative_self(),
+                &sel4::init_thread::slot::CNODE
+                    .cap()
+                    .absolute_cptr_for_self(),
                 slot_index,
                 1,
             )

--- a/crates/examples/root-task/spawn-thread/src/main.rs
+++ b/crates/examples/root-task/spawn-thread/src/main.rs
@@ -91,7 +91,9 @@ impl ObjectAllocator {
         self.ut
             .untyped_retype(
                 &T::object_blueprint(),
-                &sel4::init_thread::slot::CNODE.cap().relative_self(),
+                &sel4::init_thread::slot::CNODE
+                    .cap()
+                    .absolute_cptr_for_self(),
                 slot_index,
                 1,
             )
@@ -108,7 +110,9 @@ impl ObjectAllocator {
         self.ut
             .untyped_retype(
                 &T::object_blueprint(size_bits),
-                &sel4::init_thread::slot::CNODE.cap().relative_self(),
+                &sel4::init_thread::slot::CNODE
+                    .cap()
+                    .absolute_cptr_for_self(),
                 slot_index,
                 1,
             )

--- a/crates/sel4-capdl-initializer/core/src/hold_slots.rs
+++ b/crates/sel4-capdl-initializer/core/src/hold_slots.rs
@@ -14,13 +14,13 @@ pub(crate) struct HoldSlots<T> {
     slots: [Slot; NUM_SLOTS],
     slots_occupied: [bool; NUM_SLOTS],
     which_slot: usize,
-    relative_cptr_of: T,
+    absolute_cptr_of: T,
 }
 
 impl<T> HoldSlots<T> {
     pub(crate) fn new(
         cslot_allocator: &mut CSlotAllocator,
-        relative_cptr_of: T,
+        absolute_cptr_of: T,
     ) -> Result<Self, CapDLInitializerError> {
         Ok(Self {
             slots: {
@@ -30,7 +30,7 @@ impl<T> HoldSlots<T> {
             },
             slots_occupied: [false; NUM_SLOTS],
             which_slot: 0,
-            relative_cptr_of,
+            absolute_cptr_of,
         })
     }
 }
@@ -38,7 +38,7 @@ impl<T> HoldSlots<T> {
 impl<T: FnMut(Slot) -> AbsoluteCPtr> HoldSlots<T> {
     pub(crate) fn get_slot(&mut self) -> Result<Slot, CapDLInitializerError> {
         if self.slots_occupied[self.which_slot] {
-            (self.relative_cptr_of)(self.slots[self.which_slot]).delete()?;
+            (self.absolute_cptr_of)(self.slots[self.which_slot]).delete()?;
             self.slots_occupied[self.which_slot] = false;
         }
         Ok(self.slots[self.which_slot])

--- a/crates/sel4-capdl-initializer/core/src/lib.rs
+++ b/crates/sel4-capdl-initializer/core/src/lib.rs
@@ -479,7 +479,7 @@ impl<'a, N: ObjectName, D: Content, M: GetEmbeddedFrame, B: BorrowMut<[PerObject
                 if !entries.is_empty() {
                     let frame_object_type =
                         sel4::FrameObjectType::from_bits(obj.size_bits).unwrap();
-                    let frame = self.orig_cap::<cap_type::UnspecifiedFrame>(obj_id);
+                    let frame = self.orig_cap::<cap_type::UnspecifiedPage>(obj_id);
                     self.fill_frame(frame, frame_object_type, entries)?;
                 }
             }
@@ -489,7 +489,7 @@ impl<'a, N: ObjectName, D: Content, M: GetEmbeddedFrame, B: BorrowMut<[PerObject
 
     fn fill_frame(
         &self,
-        frame: sel4::Cap<cap_type::UnspecifiedFrame>,
+        frame: sel4::Cap<cap_type::UnspecifiedPage>,
         frame_object_type: sel4::FrameObjectType,
         fill: &[FillEntry<D>],
     ) -> Result<()> {
@@ -556,7 +556,7 @@ impl<'a, N: ObjectName, D: Content, M: GetEmbeddedFrame, B: BorrowMut<[PerObject
             let vaddr = vaddr + (i << sel4::vspace_levels::step_bits(level));
             match entry {
                 PageTableEntry::Frame(cap) => {
-                    let frame = self.orig_cap::<cap_type::UnspecifiedFrame>(cap.object);
+                    let frame = self.orig_cap::<cap_type::UnspecifiedPage>(cap.object);
                     let rights = (&cap.rights).into();
                     self.copy(frame)?
                         .frame_map(vspace, vaddr, rights, cap.vm_attributes())?;

--- a/crates/sel4-capdl-initializer/core/src/lib.rs
+++ b/crates/sel4-capdl-initializer/core/src/lib.rs
@@ -673,9 +673,9 @@ impl<'a, N: ObjectName, D: Content, M: GetEmbeddedFrame, B: BorrowMut<[PerObject
                                 if badge == 0 && rights == CapRights::all() {
                                     orig
                                 } else {
-                                    let src = init_thread::slot::CNODE.cap().relative(orig);
+                                    let src = init_thread::slot::CNODE.cap().absolute_cptr(orig);
                                     let new = self.cslot_alloc_or_panic().cap();
-                                    let dst = init_thread::slot::CNODE.cap().relative(new);
+                                    let dst = init_thread::slot::CNODE.cap().absolute_cptr(new);
                                     dst.mint(&src, rights, badge)?;
                                     new.cast()
                                 }
@@ -757,7 +757,7 @@ impl<'a, N: ObjectName, D: Content, M: GetEmbeddedFrame, B: BorrowMut<[PerObject
                 let rights = cap.rights().map(From::from).unwrap_or(CapRights::all());
                 let src = init_thread::slot::CNODE
                     .cap()
-                    .relative(self.orig_cap::<cap_type::Unspecified>(cap.obj()));
+                    .absolute_cptr(self.orig_cap::<cap_type::Unspecified>(cap.obj()));
                 let dst = cnode
                     .absolute_cptr_from_bits_with_depth((*i).try_into().unwrap(), obj.size_bits);
                 match badge {
@@ -784,7 +784,7 @@ impl<'a, N: ObjectName, D: Content, M: GetEmbeddedFrame, B: BorrowMut<[PerObject
 
     fn copy<U: sel4::CapType>(&mut self, cap: sel4::Cap<U>) -> Result<sel4::Cap<U>> {
         let slot = self.cslot_alloc_or_panic();
-        let src = init_thread::slot::CNODE.cap().relative(cap);
+        let src = init_thread::slot::CNODE.cap().absolute_cptr(cap);
         cslot_to_relative_cptr(slot).copy(&src, CapRights::all())?;
         Ok(slot.cap().downcast())
     }
@@ -823,7 +823,7 @@ impl<'a, N: ObjectName, D: Content, M: GetEmbeddedFrame, B: BorrowMut<[PerObject
 }
 
 fn cslot_to_relative_cptr(slot: Slot) -> sel4::AbsoluteCPtr {
-    init_thread::slot::CNODE.cap().relative(slot.cptr())
+    init_thread::slot::CNODE.cap().absolute_cptr(slot.cptr())
 }
 
 fn init_thread_cnode_relative_cptr() -> sel4::AbsoluteCPtr {

--- a/crates/sel4-capdl-initializer/core/src/lib.rs
+++ b/crates/sel4-capdl-initializer/core/src/lib.rs
@@ -826,5 +826,5 @@ fn cslot_to_relative_cptr(slot: Slot) -> sel4::AbsoluteCPtr {
 }
 
 fn init_thread_cnode_relative_cptr() -> sel4::AbsoluteCPtr {
-    init_thread::slot::CNODE.cap().relative_self()
+    init_thread::slot::CNODE.cap().absolute_cptr_for_self()
 }

--- a/crates/sel4-capdl-initializer/core/src/lib.rs
+++ b/crates/sel4-capdl-initializer/core/src/lib.rs
@@ -758,7 +758,8 @@ impl<'a, N: ObjectName, D: Content, M: GetEmbeddedFrame, B: BorrowMut<[PerObject
                 let src = init_thread::slot::CNODE
                     .cap()
                     .relative(self.orig_cap::<cap_type::Unspecified>(cap.obj()));
-                let dst = cnode.relative_bits_with_depth((*i).try_into().unwrap(), obj.size_bits);
+                let dst = cnode
+                    .absolute_cptr_from_bits_with_depth((*i).try_into().unwrap(), obj.size_bits);
                 match badge {
                     None => dst.copy(&src, rights),
                     Some(badge) => dst.mint(&src, rights, badge),

--- a/crates/sel4-capdl-initializer/core/src/memory.rs
+++ b/crates/sel4-capdl-initializer/core/src/memory.rs
@@ -18,10 +18,10 @@ const SMALL_PAGE_PLACEHOLDER_SIZE: usize = if sel4_cfg_bool!(ARCH_AARCH32) {
 #[repr(C)]
 #[sel4_cfg_attr(ARCH_AARCH32, repr(align(65536)))]
 #[sel4_cfg_attr(not(ARCH_AARCH32), repr(align(4096)))]
-struct SmallPagePlaceHolder(#[allow(dead_code)] [u8; SMALL_PAGE_PLACEHOLDER_SIZE]);
+struct SmallPagePlaceholder(#[allow(dead_code)] [u8; SMALL_PAGE_PLACEHOLDER_SIZE]);
 
-static SMALL_PAGE_PLACEHOLDER: SmallPagePlaceHolder =
-    SmallPagePlaceHolder([0; SMALL_PAGE_PLACEHOLDER_SIZE]);
+static SMALL_PAGE_PLACEHOLDER: SmallPagePlaceholder =
+    SmallPagePlaceholder([0; SMALL_PAGE_PLACEHOLDER_SIZE]);
 
 pub(crate) struct CopyAddrs {
     smaller_frame_copy_addr: usize,

--- a/crates/sel4-panicking/env/src/lib.rs
+++ b/crates/sel4-panicking/env/src/lib.rs
@@ -188,7 +188,15 @@ pub fn __abort_macro_helper(message: Option<fmt::Arguments>) -> ! {
 
 /// Aborts execution with a message.
 ///
-/// This function first invokes an externally defined abort hook which is resolved at link time, and
+/// [`abort!`] accepts the same patterns `core::panic!`:
+///
+/// ```rust
+/// abort!();
+/// abort!("uh oh!");
+/// abort!("uh {} {}!", 123, "oh");
+/// ```
+///
+/// This macro first invokes an externally defined abort hook which is resolved at link time, and
 /// then calls `core::intrinsics::abort()`.
 ///
 /// The following externally defined symbol is used as the abort hook:

--- a/crates/sel4-panicking/src/hook.rs
+++ b/crates/sel4-panicking/src/hook.rs
@@ -9,10 +9,14 @@ use sel4_panicking_env::debug_println;
 
 use crate::ExternalPanicInfo;
 
+/// Type for panic hooks.
+///
+/// See [`set_hook`].
 pub type PanicHook = &'static (dyn Fn(&ExternalPanicInfo) + Send + Sync);
 
 static PANIC_HOOK: ImmediateSyncOnceCell<PanicHook> = ImmediateSyncOnceCell::new();
 
+/// Like `std::panic::set_hook`.
 pub fn set_hook(hook: PanicHook) {
     PANIC_HOOK.set(hook).unwrap_or_else(|_| panic!())
 }

--- a/crates/sel4-panicking/src/lib.rs
+++ b/crates/sel4-panicking/src/lib.rs
@@ -44,6 +44,9 @@ pub use payload::{Payload, SmallPayload, UpcastIntoPayload, SMALL_PAYLOAD_MAX_SI
 #[cfg(not(panic_info_message_stable))]
 pub type PanicMessage<'a> = &'a fmt::Arguments<'a>;
 
+/// Information passed to a [`PanicHook`].
+///
+/// Analogous to `std::panic::PanicHookInfo`.
 pub struct ExternalPanicInfo<'a> {
     payload: Payload,
     message: Option<PanicMessage<'a>>,
@@ -98,6 +101,7 @@ fn panic(info: &PanicInfo) -> ! {
     })
 }
 
+/// Like `std::panic::panic_any`.
 #[track_caller]
 pub fn panic_any<M: UpcastIntoPayload>(msg: M) -> ! {
     do_panic(ExternalPanicInfo {
@@ -127,6 +131,7 @@ cfg_if! {
     }
 }
 
+/// Like `std::panic::catch_unwind`.
 pub fn catch_unwind<R, F: FnOnce() -> R + UnwindSafe>(f: F) -> Result<R, Payload> {
     union Data<F, R> {
         f: ManuallyDrop<F>,

--- a/crates/sel4-root-task/src/entry.rs
+++ b/crates/sel4-root-task/src/entry.rs
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
-use core::fmt;
 use core::panic::UnwindSafe;
 
 use crate::{abort, panicking::catch_unwind, Termination};
@@ -60,13 +59,10 @@ macro_rules! declare_main {
 
 #[doc(hidden)]
 #[allow(clippy::missing_safety_doc)]
-pub fn run_main<T>(
-    f: impl FnOnce(&sel4::BootInfoPtr) -> T + UnwindSafe,
-    bootinfo: &sel4::BootInfoPtr,
-) -> !
+pub fn run_main<F, T>(f: F, bootinfo: &sel4::BootInfoPtr) -> !
 where
+    F: FnOnce(&sel4::BootInfoPtr) -> T + UnwindSafe,
     T: Termination,
-    T::Error: fmt::Debug,
 {
     let result = catch_unwind(move || f(bootinfo).report());
     match result {

--- a/crates/sel4-root-task/src/heap.rs
+++ b/crates/sel4-root-task/src/heap.rs
@@ -10,6 +10,10 @@ use sel4_panicking_env::abort;
 static GLOBAL_ALLOCATOR_MUTEX_NOTIFICATION: ImmediateSyncOnceCell<sel4::cap::Notification> =
     ImmediateSyncOnceCell::new();
 
+/// Provides the global allocator with a [`sel4::cap::Notification`] to use as a mutex..
+///
+/// Until this function is used, contention in the global allocator will result in a panic. This is
+/// only useful for multi-threaded root tasks.
 pub fn set_global_allocator_mutex_notification(nfn: sel4::cap::Notification) {
     GLOBAL_ALLOCATOR_MUTEX_NOTIFICATION
         .set(nfn)

--- a/crates/sel4-root-task/src/lib.rs
+++ b/crates/sel4-root-task/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![no_std]
 #![feature(cfg_target_thread_local)]
+#![feature(linkage)]
 #![feature(never_type)]
 
 pub use sel4_panicking_env::abort;

--- a/crates/sel4-root-task/src/lib.rs
+++ b/crates/sel4-root-task/src/lib.rs
@@ -4,13 +4,36 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
+//! A runtime for root tasks.
+//!
+//! This crate defines an entrypoint at `_start` that performs the following Rust language runtime
+//! and [`libsel4`](sel4) initialization:
+//! - Set up the stack
+//! - Initialize thread-local storage (using stack memory)
+//! - Set up exception handling
+//! - Set the seL4 IPC buffer for `libsel4` (using [`sel4::set_ipc_buffer`])
+//! - Run C-style constructors (from `__init_array_start`/`__init_array_end`)
+//!
+//! After initialization, the entrypoint calls the root task main function, which must be declared
+//! with [`#[root_task]`](root_task). For example:
+//!
+//! ```rust
+//! #[root_task]
+//! fn main(bootinfo: &sel4::BootInfo) -> ! {
+//!     todo!()
+//! }
+//! ```
+//!
+//! Building root tasks using this crate does not require a custom linker script when using `LLD`.
+//! In particular, this crate is tested with the `LLD` binary that ships with `rustc` (`rust-lld`).
+//! Using a GNU linker will likely require a custom linker script.
+
 #![no_std]
 #![feature(cfg_target_thread_local)]
 #![feature(linkage)]
 #![feature(never_type)]
 
 pub use sel4_panicking_env::abort;
-pub use sel4_root_task_macros::root_task;
 
 #[doc(inline)]
 pub use sel4_panicking as panicking;
@@ -26,6 +49,42 @@ pub use termination::{Never, Termination};
 #[sel4::sel4_cfg(PRINTING)]
 pub use sel4_panicking_env::{debug_print, debug_println};
 
+/// Declares a function to be the root task's main function.
+///
+/// For example:
+///
+/// ```rust
+/// #[root_task]
+/// fn main(bootinfo: &sel4::BootInfo) -> ! {
+///     todo!()
+/// }
+/// ```
+///
+///
+/// The main function have a signature of the form:
+///
+/// ```rust
+/// fn<T: sel4_root_task::Termination>(&sel4::BootInfoPtr) -> T
+/// ```
+///
+/// (See [`Termination`])
+///
+/// This macro takes two optional parameters:
+///
+/// ```rust
+/// #[root_task(stack_size = <stack_size_expr: usize>, heap_size = <heap_size_expr: usize>)]
+/// ```
+///
+/// - `stack_size`: Declares the size of the initial thread's stack, in bytes. Note that this
+///   includes space for thread-local storage. If absent, [`DEFAULT_STACK_SIZE`] will be used.
+/// - `heap_size`: Creates a `#[global_allocator]`, backed by a static heap of the specified size.
+///   If this parameter is not specified, no `#[global_allocator]` will be automatically declared,
+///   and, unless one is manually declared, heap allocations will result in a link-time error.
+///
+/// Note that, if both parameters are provided, they must appear in the order above.
+pub use sel4_root_task_macros::root_task;
+
+#[doc(hidden)]
 #[macro_export]
 macro_rules! declare_root_task {
     {
@@ -56,6 +115,7 @@ macro_rules! declare_root_task {
     };
 }
 
+/// The default stack size used by [`#[root_task]`](crate::root_task).
 pub const DEFAULT_STACK_SIZE: usize = 1024
     * if cfg!(panic = "unwind") && cfg!(debug_assertions) {
         128

--- a/crates/sel4-root-task/src/printing.rs
+++ b/crates/sel4-root-task/src/printing.rs
@@ -39,4 +39,7 @@ sel4_cfg_if! {
     }
 }
 
-sel4_panicking_env::register_debug_put_char!(debug_put_char);
+sel4_panicking_env::register_debug_put_char!(
+    #[linkage = "weak"]
+    debug_put_char
+);

--- a/crates/sel4-root-task/src/printing.rs
+++ b/crates/sel4-root-task/src/printing.rs
@@ -15,7 +15,7 @@ sel4_cfg_if! {
         // Create new no-op macros instead of re-exporting from sel4_panicking_env for the sake of
         // performance.
 
-        /// No-op for this configuration
+        /// No-op for this configuration.
         #[macro_export]
         macro_rules! debug_print {
             ($($arg:tt)*) => {
@@ -26,7 +26,7 @@ sel4_cfg_if! {
             };
         }
 
-        /// No-op for this configuration
+        /// No-op for this configuration.
         #[macro_export]
         macro_rules! debug_println {
             ($($arg:tt)*) => {

--- a/crates/sel4-root-task/src/termination.rs
+++ b/crates/sel4-root-task/src/termination.rs
@@ -6,6 +6,7 @@
 
 use core::fmt;
 
+/// Trait for the return type of [`#[root_task]`](crate::root_task) main functions.
 pub trait Termination {
     type Error: fmt::Debug;
 
@@ -53,6 +54,11 @@ impl<E: fmt::Debug> Termination for Result<Never, E> {
 }
 
 // NOTE(rustc_wishlist) remove once #![never_type] is stabilized
+/// Stable alternative to `!`.
+///
+/// This type in uninhabited like `!`, but does not require the unstable `#[feature(never_type)]`.
+/// It implements [`Termination`], so it is useful in return types for
+/// [`#[root_task]`](crate::root_task) main functions.
 #[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub enum Never {}
 

--- a/crates/sel4-root-task/src/termination.rs
+++ b/crates/sel4-root-task/src/termination.rs
@@ -7,7 +7,7 @@
 use core::fmt;
 
 pub trait Termination {
-    type Error;
+    type Error: fmt::Debug;
 
     fn report(self) -> Self::Error;
 }
@@ -28,7 +28,7 @@ impl Termination for Never {
     }
 }
 
-impl<E> Termination for Result<!, E> {
+impl<E: fmt::Debug> Termination for Result<!, E> {
     type Error = E;
 
     fn report(self) -> Self::Error {
@@ -40,7 +40,7 @@ impl<E> Termination for Result<!, E> {
     }
 }
 
-impl<E> Termination for Result<Never, E> {
+impl<E: fmt::Debug> Termination for Result<Never, E> {
     type Error = E;
 
     fn report(self) -> Self::Error {

--- a/crates/sel4/config/macros/src/lib.rs
+++ b/crates/sel4/config/macros/src/lib.rs
@@ -150,9 +150,9 @@ pub fn sel4_cfg_if(toks: TokenStream) -> TokenStream {
     get_impls().cfg_if_impl(toks.into()).into()
 }
 
-/// Like `core::cfg!()`, except using the seL4 kernel configuration.
+/// Like `core::cfg!`, except using the seL4 kernel configuration.
 ///
-/// Unlike `core::cfg!()`, this macro requires the configuration key to correspond to a boolean
+/// Unlike `core::cfg!`, this macro requires the configuration key to correspond to a boolean
 /// value.
 ///
 /// See [`macro@sel4_cfg`] for documentation on the configuration expression syntax.
@@ -169,7 +169,7 @@ pub fn sel4_cfg_bool(key_toks: TokenStream) -> TokenStream {
     get_impls().cfg_bool_impl(key_toks.into()).into()
 }
 
-/// Like `core::cfg!()`, except using the seL4 kernel configuration.
+/// Like `core::cfg!`, except using the seL4 kernel configuration.
 ///
 /// This macro requires the configuration key to correspond to a string value. It parses that value
 /// into an integer at compile-time, and assignes to it the type `usize`.
@@ -188,7 +188,7 @@ pub fn sel4_cfg_str(key_toks: TokenStream) -> TokenStream {
         .into()
 }
 
-/// Like `core::cfg!()`, except using the seL4 kernel configuration.
+/// Like `core::cfg!`, except using the seL4 kernel configuration.
 ///
 /// This macro requires the configuration key to correspond to a string value. It parses that value
 /// into an integer at compile-time, and assigns it type `usize`.
@@ -207,7 +207,7 @@ pub fn sel4_cfg_usize(key_toks: TokenStream) -> TokenStream {
         .into()
 }
 
-/// Like `core::cfg!()`, except using the seL4 kernel configuration.
+/// Like `core::cfg!`, except using the seL4 kernel configuration.
 ///
 /// This macro requires the configuration key to correspond to a string value. It parses that value
 /// into an integer at compile-time, and assigns to it the one of the types `u32` or `u64`,

--- a/crates/sel4/src/arch/arm/fault.rs
+++ b/crates/sel4/src/arch/arm/fault.rs
@@ -9,23 +9,24 @@ use sel4_config::{sel4_cfg, sel4_cfg_enum, sel4_cfg_if, sel4_cfg_wrap_match};
 
 use crate::{declare_fault_newtype, sys, Word};
 
-declare_fault_newtype!(NullFault, sys::seL4_Fault_NullFault);
-declare_fault_newtype!(CapFault, sys::seL4_Fault_CapFault);
-declare_fault_newtype!(UnknownSyscall, sys::seL4_Fault_UnknownSyscall);
-declare_fault_newtype!(UserException, sys::seL4_Fault_UserException);
-declare_fault_newtype!(VmFault, sys::seL4_Fault_VMFault);
+declare_fault_newtype!(NullFault, seL4_Fault_NullFault);
+declare_fault_newtype!(CapFault, seL4_Fault_CapFault);
+declare_fault_newtype!(UnknownSyscall, seL4_Fault_UnknownSyscall);
+declare_fault_newtype!(UserException, seL4_Fault_UserException);
+declare_fault_newtype!(VmFault, seL4_Fault_VMFault);
 
 #[sel4_cfg(KERNEL_MCS)]
-declare_fault_newtype!(Timeout, sys::seL4_Fault_Timeout);
+declare_fault_newtype!(Timeout, seL4_Fault_Timeout);
 
 sel4_cfg_if! {
     if #[sel4_cfg(ARM_HYPERVISOR_SUPPORT)] {
-        declare_fault_newtype!(VGicMaintenance, sys::seL4_Fault_VGICMaintenance);
-        declare_fault_newtype!(VCpuFault, sys::seL4_Fault_VCPUFault);
-        declare_fault_newtype!(VPpiEvent, sys::seL4_Fault_VPPIEvent);
+        declare_fault_newtype!(VGicMaintenance, seL4_Fault_VGICMaintenance);
+        declare_fault_newtype!(VCpuFault, seL4_Fault_VCPUFault);
+        declare_fault_newtype!(VPpiEvent, seL4_Fault_VPPIEvent);
     }
 }
 
+/// Corresponds to `seL4_Fault`.
 #[sel4_cfg_enum]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Fault {

--- a/crates/sel4/src/arch/arm/vspace.rs
+++ b/crates/sel4/src/arch/arm/vspace.rs
@@ -184,6 +184,6 @@ pub mod vspace_levels {
 
     pub const NUM_LEVELS: usize = if sel4_cfg_bool!(ARCH_AARCH64) { 4 } else { 2 };
 
-    pub const FIRST_LEVEL_WITH_FRAME_ENTRIES: usize =
+    pub const HIGHEST_LEVEL_WITH_PAGE_ENTRIES: usize =
         NUM_LEVELS - if sel4_cfg_bool!(ARCH_AARCH64) { 3 } else { 2 };
 }

--- a/crates/sel4/src/arch/arm/vspace.rs
+++ b/crates/sel4/src/arch/arm/vspace.rs
@@ -18,7 +18,7 @@ use crate::ObjectBlueprintAArch64;
 #[sel4_cfg(ARCH_AARCH32)]
 use crate::ObjectBlueprintAArch32;
 
-/// Frame sizes for AArch64.
+/// Frame object types for this kernel configuration.
 #[sel4_cfg_enum]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum FrameObjectType {
@@ -103,8 +103,9 @@ impl CapTypeForFrameObjectOfFixedSize for cap_type::Section {
     const FRAME_OBJECT_TYPE: FrameObjectType = FrameObjectType::Section;
 }
 
-//
+// // //
 
+/// Translation table object types for this kernel configuration.
 #[sel4_cfg_enum]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum TranslationTableObjectType {

--- a/crates/sel4/src/arch/riscv/fault.rs
+++ b/crates/sel4/src/arch/riscv/fault.rs
@@ -8,14 +8,14 @@ use sel4_config::{sel4_cfg, sel4_cfg_enum, sel4_cfg_wrap_match};
 
 use crate::{declare_fault_newtype, sys};
 
-declare_fault_newtype!(NullFault, sys::seL4_Fault_NullFault);
-declare_fault_newtype!(CapFault, sys::seL4_Fault_CapFault);
-declare_fault_newtype!(UnknownSyscall, sys::seL4_Fault_UnknownSyscall);
-declare_fault_newtype!(UserException, sys::seL4_Fault_UserException);
-declare_fault_newtype!(VmFault, sys::seL4_Fault_VMFault);
+declare_fault_newtype!(NullFault, seL4_Fault_NullFault);
+declare_fault_newtype!(CapFault, seL4_Fault_CapFault);
+declare_fault_newtype!(UnknownSyscall, seL4_Fault_UnknownSyscall);
+declare_fault_newtype!(UserException, seL4_Fault_UserException);
+declare_fault_newtype!(VmFault, seL4_Fault_VMFault);
 
 #[sel4_cfg(KERNEL_MCS)]
-declare_fault_newtype!(Timeout, sys::seL4_Fault_Timeout);
+declare_fault_newtype!(Timeout, seL4_Fault_Timeout);
 
 #[sel4_cfg_enum]
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/sel4/src/arch/riscv/vspace.rs
+++ b/crates/sel4/src/arch/riscv/vspace.rs
@@ -116,7 +116,7 @@ pub mod vspace_levels {
 
     pub const NUM_LEVELS: usize = sel4_cfg_usize!(PT_LEVELS);
 
-    pub const FIRST_LEVEL_WITH_FRAME_ENTRIES: usize = NUM_LEVELS
+    pub const HIGHEST_LEVEL_WITH_PAGE_ENTRIES: usize = NUM_LEVELS
         - if sel4_cfg_usize!(PT_LEVELS) == 3 || sel4_cfg_usize!(PT_LEVELS) == 4 {
             3
         } else {

--- a/crates/sel4/src/arch/riscv/vspace.rs
+++ b/crates/sel4/src/arch/riscv/vspace.rs
@@ -15,6 +15,7 @@ use crate::{
     ObjectBlueprintRiscV,
 };
 
+/// Frame object types for this kernel configuration.
 #[sel4_config::sel4_cfg_enum]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum FrameObjectType {
@@ -79,8 +80,9 @@ impl CapTypeForFrameObjectOfFixedSize for cap_type::GigaPage {
     const FRAME_OBJECT_TYPE: FrameObjectType = FrameObjectType::GigaPage;
 }
 
-//
+// // //
 
+/// Translation table object types for this kernel configuration.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum TranslationTableObjectType {
     PageTable,

--- a/crates/sel4/src/arch/x86/fault.rs
+++ b/crates/sel4/src/arch/x86/fault.rs
@@ -8,14 +8,14 @@ use sel4_config::{sel4_cfg, sel4_cfg_enum, sel4_cfg_wrap_match};
 
 use crate::{declare_fault_newtype, sys};
 
-declare_fault_newtype!(NullFault, sys::seL4_Fault_NullFault);
-declare_fault_newtype!(CapFault, sys::seL4_Fault_CapFault);
-declare_fault_newtype!(UnknownSyscall, sys::seL4_Fault_UnknownSyscall);
-declare_fault_newtype!(UserException, sys::seL4_Fault_UserException);
-declare_fault_newtype!(VmFault, sys::seL4_Fault_VMFault);
+declare_fault_newtype!(NullFault, seL4_Fault_NullFault);
+declare_fault_newtype!(CapFault, seL4_Fault_CapFault);
+declare_fault_newtype!(UnknownSyscall, seL4_Fault_UnknownSyscall);
+declare_fault_newtype!(UserException, seL4_Fault_UserException);
+declare_fault_newtype!(VmFault, seL4_Fault_VMFault);
 
 #[sel4_cfg(KERNEL_MCS)]
-declare_fault_newtype!(Timeout, sys::seL4_Fault_Timeout);
+declare_fault_newtype!(Timeout, seL4_Fault_Timeout);
 
 #[sel4_cfg_enum]
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/sel4/src/arch/x86/vspace.rs
+++ b/crates/sel4/src/arch/x86/vspace.rs
@@ -132,5 +132,5 @@ impl CapTypeForTranslationTableObject for cap_type::PageTable {
 pub mod vspace_levels {
     pub const NUM_LEVELS: usize = 4;
 
-    pub const FIRST_LEVEL_WITH_FRAME_ENTRIES: usize = NUM_LEVELS - 3;
+    pub const HIGHEST_LEVEL_WITH_PAGE_ENTRIES: usize = NUM_LEVELS - 3;
 }

--- a/crates/sel4/src/arch/x86/vspace.rs
+++ b/crates/sel4/src/arch/x86/vspace.rs
@@ -10,6 +10,7 @@ use crate::{
     ObjectBlueprintX64, ObjectBlueprintX86,
 };
 
+/// Frame object types for this kernel configuration.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum FrameObjectType {
     _4k,
@@ -63,8 +64,9 @@ impl CapTypeForFrameObjectOfFixedSize for cap_type::HugePage {
     const FRAME_OBJECT_TYPE: FrameObjectType = FrameObjectType::HugePage;
 }
 
-//
+// // //
 
+/// Translation table object types for this kernel configuration.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum TranslationTableObjectType {
     PML4,

--- a/crates/sel4/src/benchmark.rs
+++ b/crates/sel4/src/benchmark.rs
@@ -17,7 +17,7 @@ pub fn benchmark_finalize_log() -> Word {
     sys::seL4_BenchmarkFinalizeLog()
 }
 
-pub fn benchmark_set_log_buffer(frame: cap::UnspecifiedFrame) -> Result<()> {
+pub fn benchmark_set_log_buffer(frame: cap::UnspecifiedPage) -> Result<()> {
     Error::wrap(sys::seL4_BenchmarkSetLogBuffer(frame.bits()))
 }
 

--- a/crates/sel4/src/cptr.rs
+++ b/crates/sel4/src/cptr.rs
@@ -54,6 +54,7 @@ impl CPtrWithDepth {
         self.depth
     }
 
+    /// The [`CPtrWithDepth`] with a depth of 0.
     pub const fn empty() -> Self {
         Self::from_bits_with_depth(0, 0)
     }
@@ -321,6 +322,11 @@ impl<C> Unspecified<C> {
 /// current thread's capability space.
 ///
 /// `seL4_CNode_*` capability invocations are methods of [`AbsoluteCPtr`] rather than [`Cap`].
+///
+/// In addition to [`AbsoluteCPtr::new`], the following methods can be used to construct an [`AbsoluteCPtr`]:
+/// - [`CNode::absolute_cptr`]
+/// - [`CNode::absolute_cptr_from_bits_with_depth`]
+/// - [`CNode::absolute_cptr_for_self`]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct AbsoluteCPtr<C = NoExplicitInvocationContext> {
     root: CNode<C>,
@@ -368,6 +374,7 @@ impl<C: InvocationContext> AbsoluteCPtr<C> {
 ///
 /// [`CPtr`] and [`Cap`] each logically contain a [`CPtrWithDepth`] with a depth of [`WORD_SIZE`].
 pub trait HasCPtrWithDepth {
+    /// Returns the logical [`CPtrWithDepth`] entailed by `self`.
     fn cptr_with_depth(self) -> CPtrWithDepth;
 }
 
@@ -390,6 +397,7 @@ impl HasCPtrWithDepth for CPtrWithDepth {
 }
 
 impl<C> CNode<C> {
+    /// Returns the [`AbsoluteCPtr`] for `path` in the context of `self`.
     pub fn absolute_cptr<T: HasCPtrWithDepth>(self, path: T) -> AbsoluteCPtr<C> {
         AbsoluteCPtr {
             root: self,
@@ -397,6 +405,9 @@ impl<C> CNode<C> {
         }
     }
 
+    /// Returns the [`AbsoluteCPtr`] for
+    /// [`CPtrWithDepth::from_bits_with_depth(bits, depth)`](CPtrWithDepth::from_bits_with_depth)
+    /// in the context of `self`.
     pub fn absolute_cptr_from_bits_with_depth(
         self,
         bits: CPtrBits,
@@ -405,6 +416,12 @@ impl<C> CNode<C> {
         self.absolute_cptr(CPtrWithDepth::from_bits_with_depth(bits, depth))
     }
 
+    /// Returns the [`AbsoluteCPtr`] for `self` in its own context.
+    ///
+    /// Currently implemented as:
+    /// ```rust
+    /// self.absolute_cptr(CPtrWithDepth::empty())
+    /// ```
     pub fn absolute_cptr_for_self(self) -> AbsoluteCPtr<C> {
         self.absolute_cptr(CPtrWithDepth::empty())
     }

--- a/crates/sel4/src/cptr.rs
+++ b/crates/sel4/src/cptr.rs
@@ -390,7 +390,7 @@ impl HasCPtrWithDepth for CPtrWithDepth {
 }
 
 impl<C> CNode<C> {
-    pub fn relative<T: HasCPtrWithDepth>(self, path: T) -> AbsoluteCPtr<C> {
+    pub fn absolute_cptr<T: HasCPtrWithDepth>(self, path: T) -> AbsoluteCPtr<C> {
         AbsoluteCPtr {
             root: self,
             path: path.cptr_with_depth(),
@@ -402,10 +402,10 @@ impl<C> CNode<C> {
         bits: CPtrBits,
         depth: usize,
     ) -> AbsoluteCPtr<C> {
-        self.relative(CPtrWithDepth::from_bits_with_depth(bits, depth))
+        self.absolute_cptr(CPtrWithDepth::from_bits_with_depth(bits, depth))
     }
 
     pub fn absolute_cptr_for_self(self) -> AbsoluteCPtr<C> {
-        self.relative(CPtrWithDepth::empty())
+        self.absolute_cptr(CPtrWithDepth::empty())
     }
 }

--- a/crates/sel4/src/cptr.rs
+++ b/crates/sel4/src/cptr.rs
@@ -397,7 +397,11 @@ impl<C> CNode<C> {
         }
     }
 
-    pub fn relative_bits_with_depth(self, bits: CPtrBits, depth: usize) -> AbsoluteCPtr<C> {
+    pub fn absolute_cptr_from_bits_with_depth(
+        self,
+        bits: CPtrBits,
+        depth: usize,
+    ) -> AbsoluteCPtr<C> {
         self.relative(CPtrWithDepth::from_bits_with_depth(bits, depth))
     }
 

--- a/crates/sel4/src/cptr.rs
+++ b/crates/sel4/src/cptr.rs
@@ -401,7 +401,7 @@ impl<C> CNode<C> {
         self.relative(CPtrWithDepth::from_bits_with_depth(bits, depth))
     }
 
-    pub fn relative_self(self) -> AbsoluteCPtr<C> {
+    pub fn absolute_cptr_for_self(self) -> AbsoluteCPtr<C> {
         self.relative(CPtrWithDepth::empty())
     }
 }

--- a/crates/sel4/src/cptr.rs
+++ b/crates/sel4/src/cptr.rs
@@ -328,6 +328,10 @@ pub struct AbsoluteCPtr<C = NoExplicitInvocationContext> {
 }
 
 impl<C> AbsoluteCPtr<C> {
+    pub const fn new(root: CNode<C>, path: CPtrWithDepth) -> Self {
+        Self { root, path }
+    }
+
     pub const fn root(&self) -> &CNode<C> {
         &self.root
     }

--- a/crates/sel4/src/cptr.rs
+++ b/crates/sel4/src/cptr.rs
@@ -78,8 +78,11 @@ impl From<CPtr> for CPtrWithDepth {
 ///   [`ImplicitInvocationContext`](crate::ImplicitInvocationContext), which uses the [`IpcBuffer`]
 ///   set by [`set_ipc_buffer`](crate::set_ipc_buffer). Otherwise, it is an alias for
 ///   [`NoInvocationContext`](crate::NoInvocationContext), which does not implement
-///   [`InvocationContext`]. In such cases, the [`with`](Cap::with) method is used to specify
-///   an invocation context before the capability is invoked.
+///   [`InvocationContext`]. In such cases, the [`with`](Cap::with) method is used to specify an
+///   invocation context before the capability is invoked.
+///
+/// Note that `seL4_CNode_*` capability invocations are methods of [`AbsoluteCPtr`] rather than
+/// [`Cap`].
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Cap<T: CapType, C = NoExplicitInvocationContext> {
     cptr: CPtr,
@@ -312,7 +315,12 @@ impl<C> Unspecified<C> {
     }
 }
 
-/// A [`CPtrWithDepth`] in a particular [`CNode`].
+/// A [`CPtrWithDepth`] to be resolved in the context of a particular [`CNode`].
+///
+/// Used to address capability slots, including those that may not be directly addressable in the
+/// current thread's capability space.
+///
+/// `seL4_CNode_*` capability invocations are methods of [`AbsoluteCPtr`] rather than [`Cap`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct AbsoluteCPtr<C = NoExplicitInvocationContext> {
     root: CNode<C>,
@@ -353,6 +361,8 @@ impl<C: InvocationContext> AbsoluteCPtr<C> {
 }
 
 /// Trait for types whose members which logically contain a [`CPtrWithDepth`].
+///
+/// [`CPtr`] and [`Cap`] each logically contain a [`CPtrWithDepth`] with a depth of [`WORD_SIZE`].
 pub trait HasCPtrWithDepth {
     fn cptr_with_depth(self) -> CPtrWithDepth;
 }

--- a/crates/sel4/src/cptr.rs
+++ b/crates/sel4/src/cptr.rs
@@ -236,8 +236,8 @@ pub mod cap_type {
     }
 
     declare_cap_type! {
-        /// Any frame capability.
-        UnspecifiedFrame
+        /// Any page capability.
+        UnspecifiedPage
     }
 
     declare_cap_type! {
@@ -290,7 +290,7 @@ pub mod cap {
 
     declare_cap_alias!(Null);
     declare_cap_alias!(Unspecified);
-    declare_cap_alias!(UnspecifiedFrame);
+    declare_cap_alias!(UnspecifiedPage);
     declare_cap_alias!(UnspecifiedIntermediateTranslationTable);
 
     declare_cap_alias!(VSpace);

--- a/crates/sel4/src/cptr.rs
+++ b/crates/sel4/src/cptr.rs
@@ -71,7 +71,7 @@ impl From<CPtr> for CPtrWithDepth {
     }
 }
 
-/// A capability pointer in the current CSpace.
+/// A capability pointer to be resolved in the current CSpace.
 ///
 /// - The `T` parameter is a [`CapType`] marking the type of the pointed-to capability.
 /// - The `C` parameter is a strategy for discovering the current thread's IPC buffer. When the
@@ -81,6 +81,8 @@ impl From<CPtr> for CPtrWithDepth {
 ///   [`NoInvocationContext`](crate::NoInvocationContext), which does not implement
 ///   [`InvocationContext`]. In such cases, the [`with`](Cap::with) method is used to specify an
 ///   invocation context before the capability is invoked.
+///
+/// The most general way to construct a [`Cap`] is with [`CPtr::cast`].
 ///
 /// Note that `seL4_CNode_*` capability invocations are methods of [`AbsoluteCPtr`] rather than
 /// [`Cap`].
@@ -318,12 +320,16 @@ impl<C> Unspecified<C> {
 
 /// A [`CPtrWithDepth`] to be resolved in the context of a particular [`CNode`].
 ///
-/// Used to address capability slots, including those that may not be directly addressable in the
-/// current thread's capability space.
+/// [`AbsoluteCPtr`] addresses capability slots in a more general way than [`Cap`]. It allows one to
+/// address any capability slot that is directly addressable from any CNode that is directly
+/// addressible in the current thread's CSpace. Furthermore, it allows one to address capability
+/// slots that contain CNodes by limiting the lookup depth to prevent the kernel's lookup procedure
+/// from descending into the CNode contained in that slot.
 ///
 /// `seL4_CNode_*` capability invocations are methods of [`AbsoluteCPtr`] rather than [`Cap`].
 ///
-/// In addition to [`AbsoluteCPtr::new`], the following methods can be used to construct an [`AbsoluteCPtr`]:
+/// In addition to [`AbsoluteCPtr::new`], the following methods can be used to construct an
+/// [`AbsoluteCPtr`]:
 /// - [`CNode::absolute_cptr`]
 /// - [`CNode::absolute_cptr_from_bits_with_depth`]
 /// - [`CNode::absolute_cptr_for_self`]

--- a/crates/sel4/src/cptr.rs
+++ b/crates/sel4/src/cptr.rs
@@ -241,7 +241,7 @@ pub mod cap_type {
     }
 
     declare_cap_type! {
-        /// Any intermediate translation structure capability.
+        /// Any intermediate translation table capability.
         UnspecifiedIntermediateTranslationTable
     }
 

--- a/crates/sel4/src/cptr.rs
+++ b/crates/sel4/src/cptr.rs
@@ -9,12 +9,7 @@ use core::fmt;
 use core::hash::Hash;
 use core::marker::PhantomData;
 
-use sel4_config::sel4_cfg;
-
 use crate::{sys, InvocationContext, IpcBuffer, NoExplicitInvocationContext, WORD_SIZE};
-
-#[sel4_cfg(not(KERNEL_MCS))]
-use crate::Result;
 
 /// The raw bits of a capability pointer.
 pub type CPtrBits = sys::seL4_CPtr;
@@ -394,12 +389,5 @@ impl<C> CNode<C> {
 
     pub fn relative_self(self) -> AbsoluteCPtr<C> {
         self.relative(CPtrWithDepth::empty())
-    }
-}
-
-impl<C: InvocationContext> CNode<C> {
-    #[sel4_cfg(not(KERNEL_MCS))]
-    pub fn save_caller(self, ep: Endpoint) -> Result<()> {
-        self.relative(ep).save_caller()
     }
 }

--- a/crates/sel4/src/helper_macros.rs
+++ b/crates/sel4/src/helper_macros.rs
@@ -105,12 +105,15 @@ macro_rules! declare_cap_alias {
 }
 
 macro_rules! declare_fault_newtype {
-    ($t:ident, $sys:path) => {
+    ($t:ident, $sys:ident) => {
+        #[doc = "Corresponds to `"]
+        #[doc = stringify!($sys)]
+        #[doc = "`."]
         #[derive(Debug, Clone, PartialEq, Eq)]
-        pub struct $t($sys);
+        pub struct $t($crate::sys::$sys);
 
         impl $t {
-            $crate::newtype_methods!(pub $sys);
+            $crate::newtype_methods!(pub $crate::sys::$sys);
         }
     };
 }

--- a/crates/sel4/src/init_thread.rs
+++ b/crates/sel4/src/init_thread.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-//! Items that are applicable within the context of the root task's initial thread.
+//! Items that are applicable within the context of the root task's initial thread's CSpace.
 
 use core::marker::PhantomData;
 use core::ops::Range;
@@ -109,6 +109,7 @@ impl<T: CapType> SlotRegion<T> {
     }
 }
 
+/// Initial CSpace slot constants corresponding to `seL4_Cap*`.
 pub mod slot {
     use super::{cap_type, sel4_cfg, sys, Slot};
 
@@ -121,6 +122,9 @@ pub mod slot {
         ] => {
             $(
                 $(#[$outer])*
+                #[doc = "Corresponds to `"]
+                #[doc = stringify!($sys_name)]
+                #[doc = "`."]
                 pub const $name: Slot<cap_type::$cap_type> = Slot::from_sys(sys::seL4_RootCNodeCapSlots::$sys_name);
             )*
         };
@@ -155,6 +159,7 @@ pub mod slot {
     ];
 }
 
+/// Suspends the initial thread using [`slot::TCB`].
 // NOTE(rustc_wishlist) use ! once #![never_type] is stabilized
 #[cfg(feature = "state")]
 pub fn suspend_self<T>() -> T {

--- a/crates/sel4/src/ipc_buffer.rs
+++ b/crates/sel4/src/ipc_buffer.rs
@@ -64,8 +64,10 @@ impl IpcBuffer {
 
     pub fn recv_slot(&self) -> AbsoluteCPtr {
         let inner = self.inner();
-        cap::CNode::from_bits(inner.receiveCNode)
-            .relative_bits_with_depth(inner.receiveIndex, inner.receiveCNode.try_into().unwrap())
+        cap::CNode::from_bits(inner.receiveCNode).absolute_cptr_from_bits_with_depth(
+            inner.receiveIndex,
+            inner.receiveCNode.try_into().unwrap(),
+        )
     }
 
     pub fn set_recv_slot(&mut self, slot: &AbsoluteCPtr) {

--- a/crates/sel4/src/object.rs
+++ b/crates/sel4/src/object.rs
@@ -141,14 +141,17 @@ impl From<ObjectBlueprintArch> for ObjectBlueprint {
     }
 }
 
+/// Trait for [`CapType`]s which correspond to kernel objects.
 pub trait CapTypeForObject: CapType {
     fn object_type() -> ObjectType;
 }
 
+/// Trait for [`CapType`]s which correspond to kernel objects of fixed size.
 pub trait CapTypeForObjectOfFixedSize: CapTypeForObject {
     fn object_blueprint() -> ObjectBlueprint;
 }
 
+/// Trait for [`CapType`]s which correspond to kernel objects of variable size.
 pub trait CapTypeForObjectOfVariableSize: CapTypeForObject {
     fn object_blueprint(size_bits: usize) -> ObjectBlueprint;
 }

--- a/crates/sel4/src/printing.rs
+++ b/crates/sel4/src/printing.rs
@@ -33,13 +33,13 @@ pub fn debug_print_helper(args: fmt::Arguments) {
     })
 }
 
-/// Prints using `seL4_DebugPutChar`.
+/// Like `std::debug_print!`, except backed by `seL4_DebugPutChar`.
 #[macro_export]
 macro_rules! debug_print {
     ($($arg:tt)*) => ($crate::_private::printing::debug_print_helper(format_args!($($arg)*)));
 }
 
-/// Prints using `seL4_DebugPutChar`, with a newline.
+/// Like `std::debug_println!`, except backed by `seL4_DebugPutChar`.
 #[macro_export]
 macro_rules! debug_println {
     () => ($crate::debug_println!(""));

--- a/crates/sel4/src/vspace.rs
+++ b/crates/sel4/src/vspace.rs
@@ -24,22 +24,29 @@ pub trait CapTypeForFrameObject: CapType {}
 
 impl CapTypeForFrameObject for cap_type::UnspecifiedPage {}
 
-/// Trait for [`CapTypeForFrameObject`]s which correspond to frame objects of fixed size.
+/// Trait for [`CapType`]s which correspond to frame objects of fixed size.
 pub trait CapTypeForFrameObjectOfFixedSize:
     CapTypeForObjectOfFixedSize + CapTypeForFrameObject
 {
     const FRAME_OBJECT_TYPE: FrameObjectType;
 }
 
+/// Trait for [`CapType`]s which correspond to translation table objects.
 pub trait CapTypeForTranslationTableObject: CapTypeForObjectOfFixedSize {
     const TRANSLATION_TABLE_OBJECT_TYPE: TranslationTableObjectType;
 }
 
+/// Items describing the layout of address translation structures for this kernel configuration.
 pub mod vspace_levels {
     use crate::{FrameObjectType, TranslationTableObjectType};
 
-    pub use crate::arch::vspace_levels::*;
+    /// The maximum number of levels of translation tables for this kernel configuration.
+    pub use crate::arch::vspace_levels::NUM_LEVELS;
 
+    /// Lowest level of translation table whose entries can be pages rather than lower-level translation tables.
+    pub use crate::arch::vspace_levels::FIRST_LEVEL_WITH_FRAME_ENTRIES;
+
+    /// The number of address bits spanned by the given translation table level.
     pub fn span_bits(level: usize) -> usize {
         assert!(level < NUM_LEVELS);
         (level..NUM_LEVELS)
@@ -52,6 +59,7 @@ pub mod vspace_levels {
             + FrameObjectType::GRANULE.bits()
     }
 
+    /// The number of address bits spanned by entries of the given translation table level.
     pub fn step_bits(level: usize) -> usize {
         span_bits(level)
             - TranslationTableObjectType::from_level(level)

--- a/crates/sel4/src/vspace.rs
+++ b/crates/sel4/src/vspace.rs
@@ -22,7 +22,7 @@ impl FrameObjectType {
 /// Trait for [`CapType`]s which correspond to frame objects.
 pub trait CapTypeForFrameObject: CapType {}
 
-impl CapTypeForFrameObject for cap_type::UnspecifiedFrame {}
+impl CapTypeForFrameObject for cap_type::UnspecifiedPage {}
 
 /// Trait for [`CapTypeForFrameObject`]s which correspond to frame objects of fixed size.
 pub trait CapTypeForFrameObjectOfFixedSize:

--- a/crates/sel4/src/vspace.rs
+++ b/crates/sel4/src/vspace.rs
@@ -43,8 +43,8 @@ pub mod vspace_levels {
     /// The maximum number of levels of translation tables for this kernel configuration.
     pub use crate::arch::vspace_levels::NUM_LEVELS;
 
-    /// Lowest level of translation table whose entries can be pages rather than lower-level translation tables.
-    pub use crate::arch::vspace_levels::FIRST_LEVEL_WITH_FRAME_ENTRIES;
+    /// Highest level of translation table whose entries can be pages rather than lower-level translation tables.
+    pub use crate::arch::vspace_levels::HIGHEST_LEVEL_WITH_PAGE_ENTRIES;
 
     /// The number of address bits spanned by the given translation table level.
     pub fn span_bits(level: usize) -> usize {


### PR DESCRIPTION
This PR contains a few minor API changes (mostly method renames), for the sake of clarity. Most importantly:

`AbsoluteCPtr`:
- `relative` -> `absolute_cptr`
- `relative_bits_with_depth` -> `absolute_cptr_from_bits_with_depth`
- `relative_self` -> `absolute_cptr_for_self`

Other than that, it improves and expands rustdoc for the `sel4` and `sel4-root-task` crates, along with a few others.