### PR TITLE
Suppress warnings in macro expansions

### DIFF
--- a/crates/sel4-microkit/base/src/symbols.rs
+++ b/crates/sel4-microkit/base/src/symbols.rs
@@ -12,6 +12,7 @@ macro_rules! var {
     ($(#[$attrs:meta])* $symbol:ident: $ty:ty = $default:expr) => {{
         use $crate::_private::ImmutableCell;
 
+        #[allow(non_upper_case_globals)]
         $(#[$attrs])*
         #[no_mangle]
         #[link_section = ".data"]

--- a/crates/sel4-microkit/src/entry.rs
+++ b/crates/sel4-microkit/src/entry.rs
@@ -54,6 +54,7 @@ extern "C" {
 #[macro_export]
 macro_rules! declare_init {
     ($init:expr) => {
+        #[allow(non_snake_case)]
         #[no_mangle]
         fn __sel4_microkit__main() -> ! {
             $crate::_private::run_main($init);


### PR DESCRIPTION
These false-positive warnings were related to function and global variable name style.