### PR TITLE
crates/sel4: Add `ImplicitReplyAuthority::reply`

### DIFF
--- a/crates/private/support/sel4-simple-task/runtime/src/lib.rs
+++ b/crates/private/support/sel4-simple-task/runtime/src/lib.rs
@@ -99,7 +99,7 @@ pub unsafe extern "C" fn cont_fn(cont_arg: *mut sel4_runtime_common::ContArg) ->
                     sel4::cap::Reply::from_bits(thread_config.reply_authority().unwrap().try_into().unwrap())
                 } else {
                     assert!(thread_config.reply_authority().is_none());
-                    sel4::ImplicitReplyAuthority
+                    sel4::ImplicitReplyAuthority::default()
                 }
             }
         };

--- a/crates/sel4/src/reply_authority.rs
+++ b/crates/sel4/src/reply_authority.rs
@@ -6,37 +6,65 @@
 
 use sel4_config::{sel4_cfg, sel4_cfg_if};
 
-use crate::sys;
+use crate::{sys, NoExplicitInvocationContext};
 
 #[sel4_cfg(KERNEL_MCS)]
 use crate::cap;
 
+#[sel4_cfg(not(KERNEL_MCS))]
+use crate::{InvocationContext, MessageInfo};
+
 /// Configuration-dependant alias for conveying reply authority to syscalls.
-pub type ReplyAuthority = ReplyAuthorityImpl;
+pub type ReplyAuthority<C = NoExplicitInvocationContext> = ReplyAuthorityImpl<C>;
 
 sel4_cfg_if! {
     if #[sel4_cfg(KERNEL_MCS)] {
-        pub type ReplyAuthorityImpl = cap::Reply;
+        pub type ReplyAuthorityImpl<C> = cap::Reply<C>;
 
-        impl ReplyAuthority {
+        impl<C> ReplyAuthority<C> {
             pub(crate) fn into_sys_reply_authority(self) -> sys::ReplyAuthority {
                 self.bits()
             }
         }
     } else {
-        pub type ReplyAuthorityImpl = ImplicitReplyAuthority;
+        pub type ReplyAuthorityImpl<C> = ImplicitReplyAuthority<C>;
 
-        impl ReplyAuthority {
+        impl<C> ReplyAuthority<C> {
             pub(crate) fn into_sys_reply_authority(self) -> sys::ReplyAuthority {
             }
         }
 
         /// Under this configuration, no reply authority is required.
-        pub struct ImplicitReplyAuthority;
+        #[derive(Default)]
+        pub struct ImplicitReplyAuthority<C> {
+            invocation_context: C,
+        }
+
+        impl<C> ImplicitReplyAuthority<C> {
+            pub const fn new(invocation_context: C) -> Self {
+                Self {
+                    invocation_context,
+                }
+            }
+
+            pub fn into_invocation_context(self) -> C {
+                self.invocation_context
+            }
+        }
+
+        impl<C: InvocationContext> ImplicitReplyAuthority<C> {
+            /// Corresponds to `seL4_Reply`.
+            pub fn reply(self, info: MessageInfo) {
+                self.into_invocation_context()
+                    .with_context(|ipc_buffer| ipc_buffer.inner_mut().seL4_Reply(info.into_inner()))
+            }
+        }
 
         impl ConveysReplyAuthority for () {
-            fn into_reply_authority(self) -> ReplyAuthority {
-                ImplicitReplyAuthority
+            type C = NoExplicitInvocationContext;
+
+            fn into_reply_authority(self) -> ReplyAuthority<Self::C> {
+                ImplicitReplyAuthority::default()
             }
         }
     }
@@ -44,11 +72,15 @@ sel4_cfg_if! {
 
 /// Trait for types from which [`ReplyAuthority`] can be derived.
 pub trait ConveysReplyAuthority {
-    fn into_reply_authority(self) -> ReplyAuthority;
+    type C;
+
+    fn into_reply_authority(self) -> ReplyAuthority<Self::C>;
 }
 
-impl ConveysReplyAuthority for ReplyAuthority {
-    fn into_reply_authority(self) -> ReplyAuthority {
+impl<C> ConveysReplyAuthority for ReplyAuthority<C> {
+    type C = C;
+
+    fn into_reply_authority(self) -> ReplyAuthority<Self::C> {
         self
     }
 }


### PR DESCRIPTION
Entails endowing `ReplyAuthority` with a `<C(: InvocationContext)>` parameter.