### PR TITLE
crates/sel4/sys: Make clang invocation more robust

### DIFF
--- a/crates/sel4/sys/build/c.rs
+++ b/crates/sel4/sys/build/c.rs
@@ -37,10 +37,19 @@ pub fn generate_rust(
     libsel4_include_dirs: impl Iterator<Item = impl AsRef<Path>>,
     extra_blocklist: &[String],
 ) -> bindgen::Bindings {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let clang_target = match target_arch.as_str() {
+        "aarch64" => "aarch64-unknown-none",
+        "arm" => "armv7a-none-eabi",
+        "x86_64" => "x86_64-unknown-none-elf",
+        arch => arch,
+    };
+
     let mut builder = bindgen::Builder::default()
         .header_contents("wrapper.h", HEADER_CONTENTS)
         .detect_include_paths(false)
         .clang_args(libsel4_include_dirs.map(|d| format!("-I{}", d.as_ref().display())))
+        .clang_arg(format!("--target={clang_target}"))
         .ignore_functions();
 
     for item in BLOCKLIST.iter() {
@@ -49,14 +58,6 @@ pub fn generate_rust(
 
     for item in extra_blocklist.iter() {
         builder = builder.blocklist_item(item);
-    }
-
-    {
-        // TODO remove once https://github.com/rust-lang/rust-bindgen/pull/2751 is released
-        let target = env::var("TARGET").unwrap();
-        if let Some(rest) = target.strip_prefix("riscv64imac-") {
-            builder = builder.clang_arg(format!("--target=riscv64-{}", rest));
-        }
     }
 
     builder


### PR DESCRIPTION
Map architectures to known-supported targets, rather than expect clang to parse our custom target spec names.