### PR TITLE
nix: Use immutable rev for LLVM source

### DIFF
--- a/hacking/nix/rust-utils/default.nix
+++ b/hacking/nix/rust-utils/default.nix
@@ -32,13 +32,12 @@ in
 
   symlinkToRegularFile = callBuildBuildPackage ./symlink-to-regular-file.nix {};
 
-  mkCompilerRTSource = { version, hash }:
+  mkCompilerRTSource = { rev, hash }:
     let
       llvmProject = fetchFromGitHub {
         owner = "rust-lang";
         repo = "llvm-project";
-        rev = "rustc/${version}";
-        inherit hash;
+        inherit rev hash;
       };
     in
       runCommand "compiler-rt" {} ''

--- a/hacking/nix/scope/default.nix
+++ b/hacking/nix/scope/default.nix
@@ -125,8 +125,8 @@ superCallPackage ../rust-utils {} self //
   } // {
     channel = topLevelRustToolchainFile.attrs.toolchain.channel;
     compilerRTSource = mkCompilerRTSource {
-      version = "19.1-2024-07-30";
-      hash = "sha256-fV51iDAbkRmWJj0twTmQKdZdLueMAKSZR6bBtgVPCbk=";
+      rev = "rustc-1.81.0";
+      hash = "sha256-55kUrNucrs9JSlTP8nxY8bZQGx7u6xMCbJe63fN5uU8=";
     };
     mkCustomTargetPath = customTargetTripleTripleName:
       let


### PR DESCRIPTION
The `rustc/19.1-2024-07-30` ref of https://github.com/rust-lang/llvm-project is a branch, not a tag. Switch to using a tag (`rustc-1.81.0`) for the sake of purity.