### PR TITLE
Upgrade vulnerable rustls version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1763,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "log",
  "once_cell",


### PR DESCRIPTION
Found by `cargo-audit`:

https://github.com/seL4/rust-sel4/actions/runs/12033633997/job/33548265732