### PR TITLE
Fix the bug of func recv_slot

### DIFF
--- a/crates/sel4/src/ipc_buffer.rs
+++ b/crates/sel4/src/ipc_buffer.rs
@@ -66,7 +66,7 @@ impl IpcBuffer {
         let inner = self.inner();
         cap::CNode::from_bits(inner.receiveCNode).absolute_cptr_from_bits_with_depth(
             inner.receiveIndex,
-            inner.receiveCNode.try_into().unwrap(),
+            inner.receiveDepth.try_into().unwrap(),
         )
     }
 


### PR DESCRIPTION
The recv_slot function encountered a parameter bug when calling the absolute_cptr_from_bits_with_depth method