### PR TITLE
github: use central foundation workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,14 @@
+# Copyright 2025, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Actions to run on pull requests
+
+name: PR
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  pr-checks:
+    name: Checks
+    uses: seL4/ci-actions/.github/workflows/pr.yml@master

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -12,11 +12,9 @@ on:
   pull_request:
   workflow_dispatch:
 jobs:
-  check-licenses:
-    name: Check licenses
-    runs-on: ubuntu-latest
-    steps:
-      - uses: seL4/ci-actions/license-check@master
+  push-checks:
+    name: Push
+    uses: seL4/ci-actions/.github/workflows/push.yml@master
   check-source:
     name: Check source
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -88,7 +88,7 @@ jobs:
   build-everything:
     name: Build everything
     runs-on: ubuntu-latest
-    needs: [check-licenses, check-source, run-other-tests, build-docs]
+    needs: [check-source, run-other-tests, build-docs]
     steps:
       - name: Prepare to maximize build space
         run: sudo mkdir /nix


### PR DESCRIPTION
Reduce workflow file duplication using the workflow_call feature.

This will run all of the standard foundation checks. The style checker there doesn't do Rust, but hopefully that does not hurt,  it should just succeed and/or only check file types it understands.

Some of the checks run on a `pull_request` trigger only (separate workflow file), because they assume the presence of a PR.
 