### PR TITLE
Bump Microkit to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ following versions of those related projects:
   [`cd6d3b8c25d49be2b100b0608cf0613483a6fffa`](https://github.com/seL4/seL4/tree/cd6d3b8c25d49be2b100b0608cf0613483a6fffa)
   (version 13.0.0, on [github.com/seL4/seL4:master](https://github.com/seL4/seL4/tree/master))
 - seL4, when used with Microkit:
-  [`4cae30a6ef166a378d4d23697b00106ce7e4e76f`](https://github.com/seL4/seL4/tree/4cae30a6ef166a378d4d23697b00106ce7e4e76f)
+  [`968d8f6f97a37ea315243510348e933b612319f1`](https://github.com/seL4/seL4/tree/968d8f6f97a37ea315243510348e933b612319f1)
   (on [github.com/seL4/seL4:microkit](https://github.com/seL4/seL4/tree/microkit))
 - seL4 Microkit:
-  [`395cf0e5be489bbd7586b012188fc1f712cd1a57`](https://github.com/seL4/microkit/tree/395cf0e5be489bbd7586b012188fc1f712cd1a57)
-  (version 1.4.1, on [github.com/seL4/microkit:main](https://github.com/seL4/microkit/tree/main))
+  [`8aeb9f9006cf61180dea11a0a00a084a49833066`](https://github.com/seL4/microkit/tree/8aeb9f9006cf61180dea11a0a00a084a49833066)
+  (version 2.0.0, on [github.com/seL4/microkit:main](https://github.com/seL4/microkit/tree/main))
 
 ### Demos
 

--- a/crates/examples/microkit/banscii/banscii.system.template
+++ b/crates/examples/microkit/banscii/banscii.system.template
@@ -11,7 +11,7 @@
     <memory_region name="assistant_to_artist" size="0x4_000" />
     <memory_region name="artist_to_assistant" size="0x4_000" />
 
-    <protection_domain name="serial_driver" priority="254" pp="true">
+    <protection_domain name="serial_driver" priority="254">
         <program_image path="banscii-serial-driver.elf" />
         <map mr="serial_mmio" vaddr="0x2_000_000" perms="rw" setvar_vaddr="serial_register_block" />
         <irq irq="{{ serial_irq }}" id="0" />
@@ -23,7 +23,7 @@
         <map mr="assistant_to_artist" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="region_out_start" />
     </protection_domain>
 
-    <protection_domain name="artist" priority="253" pp="true">
+    <protection_domain name="artist" priority="253">
         <program_image path="banscii-artist.elf" />
         <map mr="assistant_to_artist" vaddr="0x2_004_000" perms="r" cached="true" setvar_vaddr="region_in_start" />
         <map mr="artist_to_assistant" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="region_out_start" />
@@ -31,11 +31,11 @@
 
     <channel>
         <end pd="serial_driver" id="1" />
-        <end pd="assistant" id="0" />
+        <end pd="assistant" id="0" pp="true" />
     </channel>
 
     <channel>
-        <end pd="assistant" id="1" />
+        <end pd="assistant" id="1" pp="true" />
         <end pd="artist" id="0" />
     </channel>
 

--- a/crates/examples/microkit/http-server/http-server.system
+++ b/crates/examples/microkit/http-server/http-server.system
@@ -39,19 +39,19 @@
         <map mr="virtio_blk_used" vaddr="0x4_001_000_000" perms="rw" cached="true" setvar_vaddr="virtio_blk_used" />
     </protection_domain>
 
-    <protection_domain name="pl031_driver" pp="true" priority="251">
+    <protection_domain name="pl031_driver" priority="251">
         <program_image path="microkit-http-server-example-pl031-driver.elf" />
         <map mr="pl031_mmio" vaddr="0x5_000_000_000" perms="rw" cached="false" setvar_vaddr="pl031_mmio_vaddr" />
         <irq irq="34" id="0" />
     </protection_domain>
 
-    <protection_domain name="sp804_driver" pp="true" priority="254">
+    <protection_domain name="sp804_driver" priority="254">
         <program_image path="microkit-http-server-example-sp804-driver.elf" />
         <map mr="sp804_mmio" vaddr="0x5_000_000_000" perms="rw" cached="false" setvar_vaddr="sp804_mmio_vaddr" />
         <irq irq="43" id="0" />
     </protection_domain>
 
-    <protection_domain name="virtio_net_driver" pp="true" priority="253">
+    <protection_domain name="virtio_net_driver" priority="253">
         <program_image path="microkit-http-server-example-virtio-net-driver.elf" />
 
         <map mr="virtio_mmio" vaddr="0x6_000_000_000" perms="rw" cached="false" setvar_vaddr="virtio_net_mmio_vaddr" />
@@ -69,7 +69,7 @@
         <irq irq="79" id="0" />
     </protection_domain>
 
-    <protection_domain name="virtio_blk_driver" pp="true" priority="252">
+    <protection_domain name="virtio_blk_driver" priority="252">
         <program_image path="microkit-http-server-example-virtio-blk-driver.elf" />
 
         <map mr="virtio_mmio" vaddr="0x6_000_000_000" perms="rw" cached="false" setvar_vaddr="virtio_blk_mmio_vaddr" />
@@ -86,22 +86,22 @@
     </protection_domain>
 
     <channel>
-        <end pd="http_server" id="0" />
+        <end pd="http_server" id="0" pp="true" />
         <end pd="pl031_driver" id="1" />
     </channel>
 
     <channel>
-        <end pd="http_server" id="1" />
+        <end pd="http_server" id="1" pp="true" />
         <end pd="sp804_driver" id="1" />
     </channel>
 
     <channel>
-        <end pd="http_server" id="2" />
+        <end pd="http_server" id="2" pp="true" />
         <end pd="virtio_net_driver" id="1" />
     </channel>
 
     <channel>
-        <end pd="http_server" id="3" />
+        <end pd="http_server" id="3" pp="true" />
         <end pd="virtio_blk_driver" id="1" />
     </channel>
 </system>

--- a/crates/sel4-microkit/base/src/symbols.rs
+++ b/crates/sel4-microkit/base/src/symbols.rs
@@ -165,9 +165,23 @@ pub fn pd_is_passive() -> bool {
     *maybe_extern_var!(microkit_passive: bool = false)
 }
 
+pub(crate) fn pd_irqs() -> usize {
+    *maybe_extern_var!(microkit_irqs: usize = 0)
+}
+
+pub(crate) fn pd_notifications() -> usize {
+    *maybe_extern_var!(microkit_notifications: usize = 0)
+}
+
+pub(crate) fn pd_pps() -> usize {
+    *maybe_extern_var!(microkit_pps: usize = 0)
+}
+
+const PD_NAME_LENGTH: usize = 64;
+
 /// Returns the name of this protection domain without converting to unicode.
 pub fn pd_name_bytes() -> &'static [u8] {
-    let all_bytes = maybe_extern_var!(microkit_name: [u8; 16] = [0; 16]);
+    let all_bytes = maybe_extern_var!(microkit_name: [u8; PD_NAME_LENGTH] = [0; PD_NAME_LENGTH]);
     let n = all_bytes.iter().take_while(|b| **b != 0).count();
     &all_bytes[..n]
 }

--- a/hacking/nix/scope/sources.nix
+++ b/hacking/nix/scope/sources.nix
@@ -55,14 +55,14 @@ in rec {
 
     rust-microkit = fetchGit {
       url = "https://github.com/coliasgroup/seL4.git";
-      rev = "4cae30a6ef166a378d4d23697b00106ce7e4e76f"; # branch "rust-microkit"
+      rev = "968d8f6f97a37ea315243510348e933b612319f1"; # branch "rust-microkit"
       local = localRoot + "/seL4";
     };
   };
 
   microkit = fetchGit {
     url = "https://github.com/coliasgroup/microkit.git";
-    rev = "2492fa64b2e4930e5f3beb77be8914e5f35a2746"; # branch "rust-nix"
+    rev = "f3e3265085b5a6ff547906fdee75e7aa2590884d"; # branch "rust-nix"
     local = localRoot + "/microkit";
   };
 


### PR DESCRIPTION
- Address breaking ABI changes:
    - System description `pp` attribute moved
    - PD name length increased from 16 to 64
    - Added `microkit_irqs`, `microkit_notifications`, and `microkit_pps` symbols
- Use the latter new symbols to check channel usage at runtime
 