### PR TITLE
ci: Improve job name

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -43,8 +43,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check dependencies
         run: make check-dependencies
-  run-other-tests:
-    name: Run other tests
+  run-tests:
+    name: Run tests
     runs-on: ubuntu-latest
     steps:
       - name: Prepare to maximize build space
@@ -88,7 +88,7 @@ jobs:
   build-everything:
     name: Build everything
     runs-on: ubuntu-latest
-    needs: [check-source, run-other-tests, build-docs]
+    needs: [check-source, run-tests, build-docs]
     steps:
       - name: Prepare to maximize build space
         run: sudo mkdir /nix


### PR DESCRIPTION
Now that we don't run sel4test in this repo's CI, the "other tests" are the only tests.