### PR TITLE
Fix IPC buffer token guard usage

### DIFF
--- a/crates/sel4/src/state/token.rs
+++ b/crates/sel4/src/state/token.rs
@@ -72,7 +72,7 @@ pub(crate) trait Token {
         F: FnOnce(Result<U, BorrowError>) -> T,
         G: FnOnce() -> U,
     {
-        let (_, r) = take_ok(self.try_borrow());
+        let (_tok, r) = take_ok(self.try_borrow());
         f(r.map(|_| access_resource()))
     }
 
@@ -81,7 +81,7 @@ pub(crate) trait Token {
         F: FnOnce(Result<U, BorrowMutError>) -> T,
         G: FnOnce() -> U,
     {
-        let (_, r) = take_ok(self.try_borrow_mut());
+        let (_tok, r) = take_ok(self.try_borrow_mut());
         f(r.map(|_| access_resource()))
     }
 }


### PR DESCRIPTION
Values bound to `_` are dropped immediately instead of at the end of the surrounding scope. In two instances, IPC buffer token guards, responsible for dynamically tracking the borrow status of IPC buffers, were being dropped too early because they were bound to `_`. This PR fixes that.

Addresses https://github.com/seL4/rust-sel4/issues/256#issuecomment-2900164146