### PR TITLE
nix: Use upstream Verus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,12 +306,12 @@ dependencies = [
 [[package]]
 name = "builtin"
 version = "0.1.0"
-source = "git+https://github.com/coliasgroup/verus.git?tag=keep/a60b3b7e08d514dc8e0ac3b30236db0c#a60b3b7e08d514dc8e0ac3b30236db0c3023c17a"
+source = "git+https://github.com/verus-lang/verus.git?rev=91be9dfa7609463973107093ed97f8ad1640d9ed#91be9dfa7609463973107093ed97f8ad1640d9ed"
 
 [[package]]
 name = "builtin_macros"
 version = "0.1.0"
-source = "git+https://github.com/coliasgroup/verus.git?tag=keep/a60b3b7e08d514dc8e0ac3b30236db0c#a60b3b7e08d514dc8e0ac3b30236db0c3023c17a"
+source = "git+https://github.com/verus-lang/verus.git?rev=91be9dfa7609463973107093ed97f8ad1640d9ed#91be9dfa7609463973107093ed97f8ad1640d9ed"
 dependencies = [
  "prettyplease_verus",
  "proc-macro2",
@@ -1605,7 +1605,7 @@ dependencies = [
 [[package]]
 name = "prettyplease_verus"
 version = "0.2.29"
-source = "git+https://github.com/coliasgroup/verus.git?tag=keep/a60b3b7e08d514dc8e0ac3b30236db0c#a60b3b7e08d514dc8e0ac3b30236db0c3023c17a"
+source = "git+https://github.com/verus-lang/verus.git?rev=91be9dfa7609463973107093ed97f8ad1640d9ed#91be9dfa7609463973107093ed97f8ad1640d9ed"
 dependencies = [
  "proc-macro2",
  "syn_verus",
@@ -3056,7 +3056,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "state_machines_macros"
 version = "0.1.0"
-source = "git+https://github.com/coliasgroup/verus.git?tag=keep/a60b3b7e08d514dc8e0ac3b30236db0c#a60b3b7e08d514dc8e0ac3b30236db0c3023c17a"
+source = "git+https://github.com/verus-lang/verus.git?rev=91be9dfa7609463973107093ed97f8ad1640d9ed#91be9dfa7609463973107093ed97f8ad1640d9ed"
 dependencies = [
  "indexmap 1.9.3",
  "proc-macro2",
@@ -3096,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "syn_verus"
 version = "2.0.96"
-source = "git+https://github.com/coliasgroup/verus.git?tag=keep/a60b3b7e08d514dc8e0ac3b30236db0c#a60b3b7e08d514dc8e0ac3b30236db0c3023c17a"
+source = "git+https://github.com/verus-lang/verus.git?rev=91be9dfa7609463973107093ed97f8ad1640d9ed#91be9dfa7609463973107093ed97f8ad1640d9ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3481,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "vstd"
 version = "0.1.0"
-source = "git+https://github.com/coliasgroup/verus.git?tag=keep/a60b3b7e08d514dc8e0ac3b30236db0c#a60b3b7e08d514dc8e0ac3b30236db0c3023c17a"
+source = "git+https://github.com/verus-lang/verus.git?rev=91be9dfa7609463973107093ed97f8ad1640d9ed#91be9dfa7609463973107093ed97f8ad1640d9ed"
 dependencies = [
  "builtin",
  "builtin_macros",

--- a/crates/private/tests/root-task/verus/core/Cargo.toml
+++ b/crates/private/tests/root-task/verus/core/Cargo.toml
@@ -20,14 +20,14 @@ license = "BSD-2-Clause"
 verify = true
 
 [dependencies.builtin]
-git = "https://github.com/coliasgroup/verus.git"
-tag = "keep/a60b3b7e08d514dc8e0ac3b30236db0c"
+git = "https://github.com/verus-lang/verus.git"
+rev = "91be9dfa7609463973107093ed97f8ad1640d9ed"
 
 [dependencies.builtin_macros]
-git = "https://github.com/coliasgroup/verus.git"
-tag = "keep/a60b3b7e08d514dc8e0ac3b30236db0c"
+git = "https://github.com/verus-lang/verus.git"
+rev = "91be9dfa7609463973107093ed97f8ad1640d9ed"
 
 [dependencies.vstd]
-git = "https://github.com/coliasgroup/verus.git"
-tag = "keep/a60b3b7e08d514dc8e0ac3b30236db0c"
+git = "https://github.com/verus-lang/verus.git"
+rev = "91be9dfa7609463973107093ed97f8ad1640d9ed"
 default-features = false

--- a/crates/sel4/bitfield-ops/src/lib.rs
+++ b/crates/sel4/bitfield-ops/src/lib.rs
@@ -174,7 +174,7 @@ pub fn set_bits<T: UnsignedPrimInt, U: UnsignedPrimInt + TryInto<T>>(
             offset_into_first_primitive
                 ..(offset_into_first_primitive + num_bits_for_first_primitive),
         ))
-        | checked_cast(bits_for_first_primitive) << offset_into_first_primitive;
+        | (checked_cast(bits_for_first_primitive) << offset_into_first_primitive);
 
     let mut num_bits_so_far = num_bits_for_first_primitive;
     let mut index_of_cur_primitive = index_of_first_primitive + 1;

--- a/hacking/cargo-manifest-management/manifest-scope.nix
+++ b/hacking/cargo-manifest-management/manifest-scope.nix
@@ -188,7 +188,7 @@ in rec {
   };
 
   verusSource = {
-    git = "https://github.com/coliasgroup/verus.git";
-    tag = mkKeepRef "a60b3b7e08d514dc8e0ac3b30236db0c3023c17a"; # branch dev
+    git = "https://github.com/verus-lang/verus.git";
+    rev = "91be9dfa7609463973107093ed97f8ad1640d9ed";
   };
 }

--- a/hacking/nix/rust-utils/build-crates-in-layers.nix
+++ b/hacking/nix/rust-utils/build-crates-in-layers.nix
@@ -155,11 +155,11 @@ let
 
   cargoSubcommand =
     if test
-    then "test"
+    then ["test"]
     else (
       if verifyWithVerus
-      then "verus"
-      else "build"
+      then ["verus" "build"]
+      else ["build"]
     );
 
   mkCargoInvocation = isLastLayer: runClippy: commonArgs: subcommandArgs:
@@ -174,7 +174,7 @@ let
       ${lib.optionalString runClippy ''
         cargo clippy ${joinedCommonArgs} -- -D warnings
       ''}
-      cargo ${cargoSubcommand} ${joinedCommonArgs} ${joinedSubcommandArgs}
+      cargo ${lib.concatStringsSep " " cargoSubcommand} ${joinedCommonArgs} ${joinedSubcommandArgs}
     '';
 
   findTestsCommandPrefix = targetDir: [


### PR DESCRIPTION
Now that our work on `cargo-verus` has landed upstream:

https://github.com/verus-lang/verus/pull/1138
https://github.com/verus-lang/verus/pull/1475
