### PR TITLE
Bump Nixpkgs to `nixos-25.05`

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -17,6 +17,7 @@ Files:
   hacking/nix/scope/capdl-tool/capDL-tool.nix
   hacking/nix/scope/capdl-tool/base-compat-0-12-2.nix
   hacking/nix/scope/capdl-tool/base-compat-batteries-0-12-2.nix
+  hacking/nix/scope/capdl-tool/network-3.1.4.0.nix
   hacking/nix/scope/capdl-tool/MissingH-1.5.0.1.nix
 Copyright: 2023, Colias Group, LLC
 License: BSD-2-Clause

--- a/hacking/nix/default.nix
+++ b/hacking/nix/default.nix
@@ -8,11 +8,11 @@ let
 
   defaultNixpkgsPath =
     let
-      rev = "8b1147b636a01ceffac486dc9f6babf5a47be1b5";
+      rev = "0a44fc400a2ea73cee67c4effbae10b6bb254da8"; # based on a snapshot of nixos-25.05
     in
       builtins.fetchTarball {
         url = "https://github.com/coliasgroup/nixpkgs/archive/refs/tags/keep/${builtins.substring 0 32 rev}.tar.gz";
-        sha256 = "sha256:1116a23la11rb5jhnfr6pcxk5hqrqp44bwjmd19k70nm88qicakb";
+        sha256 = "sha256:126i4sxbrj462k6aig8df6792fs6y3nnqyc8pklzv3j103f8wl36";
       };
 
 in

--- a/hacking/nix/scope/capdl-tool/Makefile
+++ b/hacking/nix/scope/capdl-tool/Makefile
@@ -8,7 +8,12 @@ top_level := ../../../..
 capdl := $(top_level)/../x/capdl/capDL-tool
 cabal2nix := $(shell nix-build $(top_level) -A pkgs.build.cabal2nix --no-out-link)/bin/cabal2nix
 
-all := capDL-tool.nix base-compat-0-12-2.nix base-compat-batteries-0-12-2.nix MissingH-1.5.0.1.nix
+all := \
+	capDL-tool.nix \
+	base-compat-0-12-2.nix \
+	base-compat-batteries-0-12-2.nix \
+	network-3.1.4.0.nix \
+	MissingH-1.5.0.1.nix
 
 .PHONY: all $(all)
 all: $(all)
@@ -21,6 +26,9 @@ base-compat-0-12-2.nix:
 
 base-compat-batteries-0-12-2.nix:
 	$(cabal2nix) cabal://base-compat-batteries-0.12.2 > $@
+
+network-3.1.4.0.nix:
+	$(cabal2nix) cabal://network-3.1.4.0 > $@
 
 MissingH-1.5.0.1.nix:
 	$(cabal2nix) cabal://MissingH-1.5.0.1 > $@

--- a/hacking/nix/scope/capdl-tool/default.nix
+++ b/hacking/nix/scope/capdl-tool/default.nix
@@ -14,6 +14,7 @@ let
     overrides = self: super: {
       base-compat = self.callPackage ./base-compat-0-12-2.nix {};
       base-compat-batteries = self.callPackage ./base-compat-batteries-0-12-2.nix {};
+      network = self.callPackage ./network-3.1.4.0.nix {};
       MissingH = self.callPackage ./MissingH-1.5.0.1.nix {};
       capDL-tool = self.callPackage ./capDL-tool.nix {
         inherit sources;

--- a/hacking/nix/scope/capdl-tool/network-3.1.4.0.nix
+++ b/hacking/nix/scope/capdl-tool/network-3.1.4.0.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, base, bytestring, deepseq, directory, hspec
+, hspec-discover, HUnit, lib, QuickCheck, temporary
+}:
+mkDerivation {
+  pname = "network";
+  version = "3.1.4.0";
+  sha256 = "b452a2afac95d9207357eb3820c719c7c7d27871ef4b6ed7bfcd03a036b9158e";
+  revision = "1";
+  editedCabalFile = "1vwxy5zj4bizgg2g0hk3dy52kjh5d7lzn33lphmvbbs36aqcslp1";
+  libraryHaskellDepends = [ base bytestring deepseq directory ];
+  testHaskellDepends = [
+    base bytestring directory hspec HUnit QuickCheck temporary
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://github.com/haskell/network";
+  description = "Low-level networking interface";
+  license = lib.licenses.bsd3;
+}

--- a/hacking/nix/scope/default.nix
+++ b/hacking/nix/scope/default.nix
@@ -10,7 +10,7 @@
 , callPackage
 , runCommand, linkFarm
 , makeWrapper
-, overrideCC, libcCross
+, overrideCC
 , fetchurl
 , qemu
 }:

--- a/hacking/nix/scope/microkit/default.nix
+++ b/hacking/nix/scope/microkit/default.nix
@@ -11,7 +11,7 @@
 , callPackage
 , cmake, ninja
 , dtc, libxml2
-, python3Packages
+, python312Packages
 , qemuForSeL4
 , sources
 , vendorLockfile
@@ -32,7 +32,7 @@ let
     src = kernelSource;
     phases = [ "unpackPhase" "patchPhase" "installPhase" ];
     nativeBuildInputs = [
-      python3Packages.sel4-deps
+      python312Packages.sel4-deps
     ];
     postPatch = ''
       # patchShebangs can't handle env -S
@@ -63,7 +63,7 @@ let
     nativeBuildInputs = [
       cmake ninja
       dtc libxml2
-      python3Packages.sel4-deps
+      python312Packages.sel4-deps
     ];
 
     depsBuildBuild = [

--- a/hacking/nix/scope/sel4/default.nix
+++ b/hacking/nix/scope/sel4/default.nix
@@ -7,7 +7,7 @@
 { lib, stdenv, writeText, buildPackages
 , cmake, ninja
 , dtc, libxml2
-, python3Packages
+, python312Packages
 , qemuForSeL4
 , sources
 }:
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     cmake ninja
     dtc libxml2
-    python3Packages.sel4-deps
+    python312Packages.sel4-deps
   ];
 
   depsBuildBuild = [

--- a/hacking/nix/scope/sel4test/default.nix
+++ b/hacking/nix/scope/sel4test/default.nix
@@ -10,7 +10,7 @@
 , fetchRepoProject
 , cmake, ninja
 , libxml2, dtc, cpio, protobuf
-, python3Packages
+, python312Packages
 , qemuForSeL4
 , git
 , sources
@@ -72,10 +72,10 @@ let
       cmake ninja
       libxml2 dtc cpio protobuf
       git
-    ] ++ (with python3Packages; [
+    ] ++ (with python312Packages; [
       aenum plyplus pyelftools simpleeval
       sel4-deps
-      buildPackages.python3Packages.protobuf
+      buildPackages.python312Packages.protobuf
     ]);
 
     hardeningDisable = [ "all" ];

--- a/hacking/nix/scope/world/capdl/mk-simple-composition-capdl-spec.nix
+++ b/hacking/nix/scope/world/capdl/mk-simple-composition-capdl-spec.nix
@@ -6,7 +6,7 @@
 
 { lib, buildPackages, runCommand, writeText, linkFarm
 , hostPlatform
-, python3Packages
+, python312Packages
 
 , sources
 
@@ -54,7 +54,7 @@ lib.fix (self: runCommand "manifest" {
 
   nativeBuildInputs = [
     sel4-simple-task-runtime-config-cli
-  ] ++ (with python3Packages; [
+  ] ++ (with python312Packages; [
     future six
     aenum sortedcontainers
     pyyaml pyelftools pyfdt

--- a/hacking/nix/scope/world/instances/c.nix
+++ b/hacking/nix/scope/world/instances/c.nix
@@ -5,7 +5,7 @@
 #
 
 { lib, stdenv, hostPlatform
-, cmake, perl, python3Packages
+, cmake, perl
 
 , crateUtils, crates
 , mkTask, seL4Modifications

--- a/hacking/nix/scope/world/instances/default.nix
+++ b/hacking/nix/scope/world/instances/default.nix
@@ -9,7 +9,7 @@
 , runCommand, linkFarm, writeText, writeScript
 
 , cpio
-, cmake, perl, python3Packages
+, cmake, perl
 , breakpointHook, bashInteractive
 
 , sources


### PR DESCRIPTION
Note that the `future` Python package, a dependency of `sel4-deps`, is unmaintained and does not support Python 3.13.