### PR TITLE
sel4-microkit: fix ChannelSet::contains() bug

### DIFF
--- a/crates/sel4-microkit/base/src/ipc.rs
+++ b/crates/sel4-microkit/base/src/ipc.rs
@@ -60,7 +60,7 @@ pub struct ChannelSet(sel4::Badge);
 
 impl ChannelSet {
     pub fn contains(&self, channel: Channel) -> bool {
-        self.0 | (1 << channel.index()) != 0
+        (self.0 & (1 << channel.index())) != 0
     }
 
     pub fn iter(&self) -> ChannelSetIter {


### PR DESCRIPTION
After switching from `Channel` to `ChannelSet` in `Handler::notify()`, we observed that all channels appeared to be contained in the set, regardless of whether they were actually present.

Fix the `ChannelSet::contains()` method to reflect the actual state of the set.