### PR TITLE
add initial zynqmp support to the kernel-loader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/drivers/virtio/hal-impl",
     "crates/drivers/virtio/net",
     "crates/examples/lionsos/serial/components/client",
+    "crates/drivers/zynqmp-xuartps",
     "crates/examples/microkit/banscii/pds/artist",
     "crates/examples/microkit/banscii/pds/artist/interface-types",
     "crates/examples/microkit/banscii/pds/assistant",

--- a/crates/drivers/zynqmp-xuartps/Cargo.toml
+++ b/crates/drivers/zynqmp-xuartps/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "sel4-zynqmp-xuartps-driver"
+version = "0.1.0"
+edition = "2021"
+license = "BSD-2-Clause"
+
+[dependencies]
+embedded-hal-nb = "1.0"
+sel4-driver-interfaces = { path = "../../sel4-driver-interfaces" }
+tock-registers = "0.9.0"

--- a/crates/drivers/zynqmp-xuartps/src/device.rs
+++ b/crates/drivers/zynqmp-xuartps/src/device.rs
@@ -1,0 +1,73 @@
+#![allow(dead_code)]
+
+use core::ops::Deref;
+
+use tock_registers::{
+    interfaces::{Readable, Writeable},
+    register_structs,
+    registers::{ReadOnly, ReadWrite},
+};
+
+const CHANNEL_STS_TX_EMPTY: u32 = 1 << 3;
+
+register_structs! {
+    #[allow(non_snake_case)]
+    pub(crate) RegisterBlock {
+        (0x000 => Control: ReadWrite<u32>),
+        (0x004 => Mode: ReadWrite<u32>),
+        (0x008 => Intpt_en: ReadWrite<u32>),
+        (0x00C => Intrp_dis: ReadWrite<u32>),
+        (0x010 => Intrp_mask: ReadWrite<u32>),
+        (0x014 => Chnl_int_sts: ReadWrite<u32>),
+        (0x018 => Baud_rate_gen: ReadWrite<u32>),
+        (0x01C => Rcvr_timeout: ReadWrite<u32>),
+        (0x020 => Rcvr_FIFO_trigger_level: ReadWrite<u32>),
+        (0x024 => Modem_ctrl: ReadWrite<u32>),
+        (0x028 => Modem_sts: ReadWrite<u32>),
+        (0x02C => Channel_sts: ReadOnly<u32>),
+        (0x030 => TX_RX_FIFO: ReadWrite<u32>),
+        (0x034 => Baud_rate_divider: ReadWrite<u32>),
+        (0x038 => Flow_delay: ReadWrite<u32>),
+        (0x03C => _reserved0),
+        (0x044 => Tx_FIFO_trigger_level: ReadWrite<u32>),
+        (0x048 => Rx_FIFO_byte_status: ReadWrite<u32>),
+        (0x04C => @END),
+    }
+}
+
+
+
+pub(crate) struct Device {
+    ptr: *mut RegisterBlock,
+}
+
+impl Device {
+    pub(crate) const unsafe fn new(ptr: *mut RegisterBlock) -> Self {
+        Self { ptr }
+    }
+
+    fn ptr(&self) -> *const RegisterBlock {
+        self.ptr
+    }
+
+    pub(crate) fn init(&self) {}
+}
+
+impl Deref for Device {
+    type Target = RegisterBlock;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.ptr() }
+    }
+}
+
+impl Device {
+    pub(crate) fn put_char(&self, c: u8) {
+        loop {
+            if self.Channel_sts.get() & CHANNEL_STS_TX_EMPTY != 0 {
+                break;
+            }
+        }
+        self.TX_RX_FIFO.set(c as u32);
+    }
+}

--- a/crates/drivers/zynqmp-xuartps/src/lib.rs
+++ b/crates/drivers/zynqmp-xuartps/src/lib.rs
@@ -1,0 +1,52 @@
+#![no_std]
+
+use core::convert::Infallible;
+
+use embedded_hal_nb::nb;
+use embedded_hal_nb::serial;
+
+mod device;
+
+use device::Device;
+
+pub struct Driver {
+    device: Device,
+}
+
+unsafe impl Send for Driver {}
+unsafe impl Sync for Driver {}
+
+impl Driver {
+    #[allow(clippy::missing_safety_doc)]
+    pub const unsafe fn new_uninit(ptr: *mut ()) -> Self {
+        Self {
+            device: Device::new(ptr.cast()),
+        }
+    }
+
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn new(ptr: *mut ()) -> Self {
+        let mut this = Self::new_uninit(ptr);
+        this.init();
+        this
+    }
+
+    pub fn init(&mut self) {
+        self.device.init();
+    }
+}
+
+impl serial::ErrorType for Driver {
+    type Error = Infallible;
+}
+
+impl serial::Write for Driver {
+    fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+        self.device.put_char(word);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        Ok(())
+    }
+}

--- a/crates/sel4-kernel-loader/Cargo.toml
+++ b/crates/sel4-kernel-loader/Cargo.toml
@@ -25,7 +25,9 @@ postcard = { version = "1.0.2", default-features = false }
 sel4-config = { path = "../sel4/config" }
 sel4-immutable-cell = { path = "../sel4-immutable-cell" }
 sel4-kernel-loader-embed-page-tables-runtime = { path = "embed-page-tables/runtime" }
-sel4-kernel-loader-payload-types = { path = "payload-types", features = ["serde"] }
+sel4-kernel-loader-payload-types = { path = "payload-types", features = [
+    "serde",
+] }
 sel4-logging = { path = "../sel4-logging" }
 sel4-platform-info = { path = "../sel4-platform-info" }
 sel4-stack = { path = "../sel4-stack" }
@@ -50,6 +52,7 @@ syn = { version = "2.0.85", features = ["parsing"] }
 
 [target."cfg(any(target_arch = \"arm\", target_arch = \"aarch64\"))".dependencies]
 sel4-bcm2835-aux-uart-driver = { path = "../drivers/bcm2835-aux-uart" }
+sel4-zynqmp-xuartps-driver = { path = "../drivers/zynqmp-xuartps" }
 sel4-pl011-driver = { path = "../drivers/pl011" }
 
 [target."cfg(any(target_arch = \"riscv32\", target_arch = \"riscv64\"))".dependencies]

--- a/crates/sel4-kernel-loader/src/plat/mod.rs
+++ b/crates/sel4-kernel-loader/src/plat/mod.rs
@@ -13,6 +13,9 @@ sel4_cfg_if! {
     } else if #[sel4_cfg(all(any(ARCH_AARCH64, ARCH_AARCH32), PLAT_BCM2711))] {
         #[path = "bcm2711/mod.rs"]
         mod imp;
+    } else if #[sel4_cfg(all(ARCH_AARCH64, PLAT_ZYNQMP))] {
+        #[path = "zynqmp/mod.rs"]
+        mod imp;
     } else if #[sel4_cfg(all(any(ARCH_RISCV64, ARCH_RISCV32), any(PLAT_SPIKE, PLAT_QEMU_RISCV_VIRT, PLAT_HIFIVE)))] {
         #[path = "riscv_generic/mod.rs"]
         mod imp;
@@ -26,6 +29,8 @@ mod bcm2711;
 mod qemu_arm_virt;
 #[cfg(any())]
 mod riscv_generic;
+#[cfg(any())]
+mod zynqmp;
 
 #[allow(unused_imports)]
 pub(crate) use imp::*;

--- a/crates/sel4-kernel-loader/src/plat/zynqmp/mod.rs
+++ b/crates/sel4-kernel-loader/src/plat/zynqmp/mod.rs
@@ -1,0 +1,45 @@
+use embedded_hal_nb::nb;
+use embedded_hal_nb::serial::Write;
+use spin::lock_api::Mutex;
+
+use sel4_zynqmp_xuartps_driver::Driver as ZynqmpXuartpsDriver;
+use sel4_config::{sel4_cfg, sel4_cfg_bool};
+
+use crate::{
+    arch::{drivers::psci, reset_cntvoff},
+    plat::Plat,
+};
+
+const SERIAL_DEVICE_BASE_ADDR: usize = 0x00FF000000;
+static SERIAL_DRIVER: Mutex<ZynqmpXuartpsDriver> = Mutex::new(get_serial_driver());
+
+const fn get_serial_driver() -> ZynqmpXuartpsDriver {
+    unsafe { ZynqmpXuartpsDriver::new_uninit(SERIAL_DEVICE_BASE_ADDR as *mut _) }
+}
+
+pub(crate) enum PlatImpl {}
+
+impl Plat for PlatImpl {
+    fn init() {}
+
+    fn init_per_core() {
+        if sel4_cfg_bool!(ARM_HYPERVISOR_SUPPORT) {
+            unsafe {
+                reset_cntvoff();
+            }
+        }
+    }
+
+    fn put_char(c: u8) {
+        nb::block!(SERIAL_DRIVER.lock().write(c)).unwrap_or_else(|err| match err {});
+    }
+
+    fn put_char_without_synchronization(c: u8) {
+        nb::block!(get_serial_driver().write(c)).unwrap_or_else(|err| match err {});
+    }
+
+
+    fn start_secondary_core(core_id: usize, sp: usize) {
+        psci::start_secondary_core(core_id, sp)
+    }
+}


### PR DESCRIPTION
Added initial support for Xilinx ZynqMP to the sel4-kernel-loader. One current problem is missing device-tree support in the kernel-loader, that is why the base address of the serial port is currently hard-coded. Any ideas on how to solve this platform dependence?