### PR TITLE
Fix 'array index out of bounds' error in fn next().

### DIFF
--- a/crates/sel4/src/bootinfo.rs
+++ b/crates/sel4/src/bootinfo.rs
@@ -165,6 +165,7 @@ impl BootInfoExtra<'_> {
 
 /// Corresponds to `seL4_BootInfoID`.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BootInfoExtraId {
     Padding,
     Fdt,

--- a/crates/sel4/src/bootinfo.rs
+++ b/crates/sel4/src/bootinfo.rs
@@ -168,14 +168,25 @@ impl BootInfoExtra<'_> {
 #[non_exhaustive]
 pub enum BootInfoExtraId {
     Padding,
-    Fdt,
+    X86VBE,          // VESA BIOS Extensions info
+    X86MBMMap,       // Multiboot Memory Map
+    X86_ACPI_RSDP,   // ACPI Root System Description Pointer
+    X86_Framebuffer, // Framebuffer info
+    X86_TSC_Freq,    // TSC frequency (in MHz)
+    FDT,             // Flattened Device Tree
 }
 
 impl BootInfoExtraId {
     pub fn from_sys(id: sys::seL4_BootInfoID::Type) -> Option<Self> {
+        use sys::seL4_BootInfoID::*;
         match id {
-            sys::seL4_BootInfoID::SEL4_BOOTINFO_HEADER_PADDING => Some(BootInfoExtraId::Padding),
-            sys::seL4_BootInfoID::SEL4_BOOTINFO_HEADER_FDT => Some(BootInfoExtraId::Fdt),
+            SEL4_BOOTINFO_HEADER_PADDING => Some(Self::Padding),
+            SEL4_BOOTINFO_HEADER_X86_VBE => Some(Self::X86VBE),
+            SEL4_BOOTINFO_HEADER_X86_MBMMAP => Some(Self::X86MBMMap),
+            SEL4_BOOTINFO_HEADER_X86_ACPI_RSDP => Some(Self::X86_ACPI_RSDP),
+            SEL4_BOOTINFO_HEADER_X86_FRAMEBUFFER => Some(Self::X86_Framebuffer),
+            SEL4_BOOTINFO_HEADER_X86_TSC_FREQ => Some(Self::X86_TSC_Freq),
+            SEL4_BOOTINFO_HEADER_FDT => Some(Self::FDT),
             _ => None,
         }
     }


### PR DESCRIPTION
I've rewritten the Iterator impl to be a bit easier on the eyes and also prevent out of bounds access panics whilst iterating.

I do suspect there is a way to implement this without using unsafe code, but I haven't gotten to it yet.

Also:
- Created a proper BootInfoHeader struct, with a payload_len() method for convenience when constructing the chunk slice in the iterator
- Declares BootInfoExtraId enum as non_exhaustive
- Adds additional enum fields to match the C enum in bootinfo_types.h