### PR TITLE
capdl: fix arm smc compiler error

### DIFF
--- a/crates/sel4-capdl-initializer/src/initialize.rs
+++ b/crates/sel4-capdl-initializer/src/initialize.rs
@@ -469,15 +469,14 @@ impl<'a, B: BorrowMut<[PerObjectBuffer]>> Initializer<'a, B> {
         sel4::sel4_cfg_if! {
             if #[sel4_cfg(all(ARCH_AARCH64, ALLOW_SMC_CALLS))] {
                 let arm_smc_maybe = self
-                    .spec
                     .objects()
                     .enumerate()
                     .find(|(_, obj)| {
-                        matches!(obj, Object::ArmSmc)
+                        matches!(obj, ArchivedObject::ArmSmc)
                     });
                 if let Some((arm_smc_obj_id, _)) = arm_smc_maybe {
                     let arm_smc_slot_idx = init_thread::slot::SMC.index();
-                    self.set_orig_cslot(arm_smc_obj_id, Slot::from_index(arm_smc_slot_idx));
+                    self.set_orig_cslot(arm_smc_obj_id.try_into().unwrap(), Slot::from_index(arm_smc_slot_idx));
                 }
             }
         }


### PR DESCRIPTION
Fix compiler error on seL4 config with `ALLOW_SMC_CALLS`.