### PR TITLE
capdl: fix printing regression

### DIFF
--- a/crates/sel4-capdl-initializer/src/lib_main.rs
+++ b/crates/sel4-capdl-initializer/src/lib_main.rs
@@ -60,7 +60,7 @@ const LOG_LEVEL: LevelFilter = {
 
 static LOGGER: Logger = LoggerBuilder::const_default()
     .level_filter(LOG_LEVEL)
-    .filter(|meta| meta.target() == "sel4_capdl_initializer_core")
+    .filter(|meta| meta.target().starts_with("sel4_capdl_initializer"))
     .write(|s| debug_print!("{}", s))
     .build();
 


### PR DESCRIPTION
Fixed a regression from https://github.com/seL4/rust-sel4/commit/d5aa4df546a1817c1bcbae20ed74ab0ced559fc7 that caused the capDL initialiser to stop printing to console.