### PR TITLE
Add support for FPU flags for PDs

### DIFF
--- a/crates/sel4-capdl-initializer/src/initialize.rs
+++ b/crates/sel4-capdl-initializer/src/initialize.rs
@@ -766,6 +766,8 @@ impl<'a> Initializer<'a> {
                     }
                 }
 
+                let fpu_disabled = obj.extra.fpu_disabled;
+
                 #[allow(unused_variables)]
                 let affinity = obj.extra.affinity.to_sel4();
 
@@ -822,6 +824,14 @@ impl<'a> Initializer<'a> {
                             fault_ep,
                         )?;
 
+                        let tcb_flags = sel4::TcbFlagsBuilder::new()
+                            .fpu_disabled(fpu_disabled)
+                            .build();
+                        tcb.tcb_set_flags(
+                            0,
+                            tcb_flags,
+                        )?;
+
                         tcb.tcb_set_timeout_endpoint(temp_fault_ep)?;
                     } else {
                         let fault_ep = sel4::CPtr::from_bits(obj.extra.master_fault_ep.as_ref().unwrap().to_sel4());
@@ -839,6 +849,14 @@ impl<'a> Initializer<'a> {
                             authority,
                             max_prio,
                             prio,
+                        )?;
+
+                        let tcb_flags = sel4::TcbFlagsBuilder::new()
+                            .fpu_disabled(fpu_disabled)
+                            .build();
+                        tcb.tcb_set_flags(
+                            0,
+                            tcb_flags,
                         )?;
 
                         sel4::sel4_cfg_if! {

--- a/crates/sel4-capdl-initializer/types/src/spec.rs
+++ b/crates/sel4-capdl-initializer/types/src/spec.rs
@@ -419,6 +419,7 @@ pub mod object {
         pub affinity: Word,
         pub prio: u8,
         pub max_prio: u8,
+        pub fpu_disabled: bool,
         pub resume: bool,
 
         pub domain: Option<u8>,

--- a/crates/sel4/src/invocations.rs
+++ b/crates/sel4/src/invocations.rs
@@ -49,6 +49,38 @@ impl<C: InvocationContext> Untyped<C> {
 const USER_CONTEXT_MAX_REG_COUNT: usize =
     mem::size_of::<sys::seL4_UserContext>() / mem::size_of::<Word>();
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct TcbFlagsBuilder(Word);
+
+impl TcbFlagsBuilder {
+    pub fn new() -> Self {
+        Self(sel4_sys::seL4_TCBFlag::seL4_TCBFlag_NoFlag)
+    }
+
+    pub fn build(self) -> Word {
+        self.0
+    }
+
+    pub fn fpu_disabled(self, val: bool) -> Self {
+        self.apply_flag_val(sel4_sys::seL4_TCBFlag::seL4_TCBFlag_fpuDisabled, val)
+    }
+
+    fn apply_flag_val(mut self, flag: Word, val: bool) -> Self {
+        if val {
+            self.0 |= flag
+        } else {
+            self.0 &= !flag
+        }
+        self
+    }
+}
+
+impl Default for TcbFlagsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<C: InvocationContext> Tcb<C> {
     /// Corresponds to `seL4_TCB_ReadRegisters`.
     pub fn tcb_read_registers(self, suspend: bool, count: Word) -> Result<UserContext> {
@@ -122,6 +154,16 @@ impl<C: InvocationContext> Tcb<C> {
                 .inner_mut()
                 .seL4_TCB_SetMCPriority(cptr.bits(), authority.bits(), mcp)
         }))
+    }
+
+    // Corresponds to `seL4_TCB_SetFlags`.
+    pub fn tcb_set_flags(self, clear: Word, set: Word) -> Result<Word> {
+        let ret = self.invoke(|cptr, ipc_buffer| {
+            ipc_buffer
+                .inner_mut()
+                .seL4_TCB_SetFlags(cptr.bits(), clear, set)
+        });
+        Error::or(ret.error, ret.flags)
     }
 
     sel4_cfg_if! {

--- a/crates/sel4/src/lib.rs
+++ b/crates/sel4/src/lib.rs
@@ -125,6 +125,7 @@ pub use cptr::{
 pub use error::{Error, Result};
 pub use fault::*;
 pub use invocation_context::{InvocationContext, NoExplicitInvocationContext, NoInvocationContext};
+pub use invocations::TcbFlagsBuilder;
 pub use ipc_buffer::IpcBuffer;
 pub use message_info::{MessageInfo, MessageInfoBuilder};
 pub use object::{

--- a/hacking/nix/scope/sources.nix
+++ b/hacking/nix/scope/sources.nix
@@ -34,7 +34,7 @@ let
 
   capdlCommon = {
     url = "https://github.com/coliasgroup/capdl.git";
-    rev = "6282fc3d4cf4a2d17c52dcdea11b08997458f9a3"; # branch rust-testing
+    rev = "e0dfb895ec7dda40a6e59eec11fe2c20dd5c831d"; # branch rust-testing
     local = localRoot + "/capdl";
     extraFilter = path: type:
       lib.hasSuffix "/.stack-work" path || lib.hasSuffix "/stack.yaml.lock" path;

--- a/hacking/src/python/capdl_simple_composition/components/elf.py
+++ b/hacking/src/python/capdl_simple_composition/components/elf.py
@@ -225,6 +225,7 @@ class ElfThread:
         tcb.prio = prio
         tcb.max_prio = max_prio
         tcb.affinity = affinity
+        tcb.fpu_disabled = False
         tcb.resume = True
         tcb['cspace'] = self.component.cnode_cap(update_guard_size=self.component.update_guard_size)
         tcb['vspace'] = Cap(self.component.pd())


### PR DESCRIPTION
Allows for PDs to specify the `fpu` flag to explicitly disable the FPU usage in them. By default it's set to `true`.