### PR TITLE
sel4: add seL4_X86_EPT_VMAttributes enum

### DIFF
--- a/crates/sel4/sys/build/xml/invocations/mod.rs
+++ b/crates/sel4/sys/build/xml/invocations/mod.rs
@@ -547,6 +547,7 @@ impl ParameterTypes {
 
         if sel4_cfg_bool!(ARCH_X86_64) {
             this.insert_enum("seL4_X86_VMAttributes", WORD_SIZE);
+            this.insert_enum("seL4_X86_EPT_VMAttributes", WORD_SIZE);
             this.insert_capability("seL4_X86_IOPort");
             this.insert_capability("seL4_X86_IOPortControl");
             this.insert_capability("seL4_X86_ASIDControl");


### PR DESCRIPTION
Necessary for rust-sel4 to build with [1] applied to seL4.

However, this patch does not need [1] to be merged for everything to work since seL4_X86_EPT_VMAttributes has always existed.

[1]: https://github.com/seL4/seL4/pull/1577