### PR TITLE
Fix incorrect VM Attributes being applied for mapping frames to x86 EPT

### DIFF
--- a/crates/sel4-capdl-initializer/src/initialize.rs
+++ b/crates/sel4-capdl-initializer/src/initialize.rs
@@ -554,7 +554,7 @@ impl<'a> Initializer<'a> {
             init_thread::slot::VSPACE.cap(),
             self.copy_addrs.select(frame_object_type),
             CapRights::read_write(),
-            vm_attributes_from_whether_cached_and_exec(true, false),
+            vm_attributes_from_whether_cached_and_exec(true, false, false),
         )?;
         for entry in fill.iter() {
             let range = try_into_usize_range(&archived_range_to_range(&entry.range)).unwrap();
@@ -628,8 +628,12 @@ impl<'a> Initializer<'a> {
                 PageTableEntry::Frame(cap) => {
                     let frame = self.orig_cap::<cap_type::UnspecifiedPage>(cap.object);
                     let rights = cap.rights.to_sel4();
-                    self.copy(frame)?
-                        .ept_frame_map(eptpml4, vaddr, rights, cap.vm_attributes())?;
+                    self.copy(frame)?.ept_frame_map(
+                        eptpml4,
+                        vaddr,
+                        rights,
+                        cap.vm_attributes(true),
+                    )?;
                 }
                 PageTableEntry::PageTable(cap) => {
                     self.orig_cap::<cap_type::UnspecifiedIntermediateTranslationTable>(cap.object)
@@ -637,7 +641,7 @@ impl<'a> Initializer<'a> {
                             sel4::TranslationTableObjectType::from_level_ept(level + 1).unwrap(),
                             eptpml4,
                             vaddr,
-                            cap.vm_attributes(),
+                            cap.vm_attributes(true),
                         )?;
                     let obj = self.object_as::<object::ArchivedPageTable>(cap.object);
                     self.init_vspace_x86_ept(eptpml4, level + 1, vaddr, obj)?;
@@ -661,7 +665,7 @@ impl<'a> Initializer<'a> {
                     let frame = self.orig_cap::<cap_type::UnspecifiedPage>(cap.object);
                     let rights = cap.rights.to_sel4();
                     self.copy(frame)?
-                        .frame_map(vspace, vaddr, rights, cap.vm_attributes())?;
+                        .frame_map(vspace, vaddr, rights, cap.vm_attributes(false))?;
                 }
                 PageTableEntry::PageTable(cap) => {
                     self.orig_cap::<cap_type::UnspecifiedIntermediateTranslationTable>(cap.object)
@@ -669,7 +673,7 @@ impl<'a> Initializer<'a> {
                             sel4::TranslationTableObjectType::from_level(level + 1).unwrap(),
                             vspace,
                             vaddr,
-                            cap.vm_attributes(),
+                            cap.vm_attributes(false),
                         )?;
                     let obj = self.object_as::<object::ArchivedPageTable>(cap.object);
                     self.init_vspace(vspace, level + 1, vaddr, obj)?;

--- a/crates/sel4-capdl-initializer/types/src/when_sel4.rs
+++ b/crates/sel4-capdl-initializer/types/src/when_sel4.rs
@@ -129,17 +129,17 @@ impl ArchivedFillEntryContentBootInfoId {
 }
 
 pub trait HasVmAttributes {
-    fn vm_attributes(&self) -> VmAttributes;
+    fn vm_attributes(&self, is_x86_ept: bool) -> VmAttributes;
 }
 
 impl HasVmAttributes for cap::ArchivedFrame {
-    fn vm_attributes(&self) -> VmAttributes {
-        vm_attributes_from_whether_cached_and_exec(self.cached, self.executable)
+    fn vm_attributes(&self, is_x86_ept: bool) -> VmAttributes {
+        vm_attributes_from_whether_cached_and_exec(self.cached, self.executable, is_x86_ept)
     }
 }
 
 impl HasVmAttributes for cap::ArchivedPageTable {
-    fn vm_attributes(&self) -> VmAttributes {
+    fn vm_attributes(&self, _is_x86_ept: bool) -> VmAttributes {
         default_vm_attributes_for_page_table()
     }
 }
@@ -159,15 +159,38 @@ sel4::sel4_cfg_if! {
     }
 }
 
+sel4::sel4_cfg_if! {
+    if #[sel4_cfg(all(ARCH_X86_64, VTX))] {
+        const EPT_CACHED: VmAttributes = VmAttributes::EPT_DEFAULT;
+        const EPT_UNCACHED: VmAttributes = VmAttributes::EPT_CACHE_DISABLED;
+    }
+}
+
 // Allow these because on some architectures, certain variables are not touched.
 #[allow(unused_variables, unused_assignments)]
-pub fn vm_attributes_from_whether_cached_and_exec(cached: bool, executable: bool) -> VmAttributes {
-    let mut vmattr = VmAttributes::NONE;
-    if cached {
-        vmattr = CACHED;
+pub fn vm_attributes_from_whether_cached_and_exec(
+    cached: bool,
+    executable: bool,
+    x86_ept: bool,
+) -> VmAttributes {
+    #[allow(unused_mut)]
+    let mut vmattr = if x86_ept {
+        sel4::sel4_cfg_if! {
+            if #[sel4_cfg(all(ARCH_X86_64, VTX))] {
+                if cached {
+                    EPT_CACHED
+                } else {
+                    EPT_UNCACHED
+                }
+            } else {
+                panic!("Encountered EPT mapping on non x86 VTX kernel build");
+            }
+        }
+    } else if cached {
+        CACHED
     } else {
-        vmattr = UNCACHED;
-    }
+        UNCACHED
+    };
 
     sel4::sel4_cfg_if! {
         if #[sel4_cfg(any(ARCH_AARCH64, ARCH_AARCH32, ARCH_RISCV64, ARCH_RISCV32))] {


### PR DESCRIPTION
Depends on https://github.com/seL4/rust-sel4/pull/317

x86 EPT support was added to the capDL Initializer in [1], but I've made a mistake of not using EPT VM Attributes when mapping frames to EPT. Since the encoding of EPT and ordinary page table VM Attributes are different. Mapping a frame to EPT as "cached" in the spec would translate to mapping it as uncached.

The fix was implemented by adding another parameter `is_x86_ept: bool` to both `vm_attributes()` and `vm_attributes_from_whether_cached_and_exec()`. I'm not sure whether this is the best approach as it seems a bit hacky. A another approach would be to define this information in the Frame cap spec object. But then you would have two places that encode this information as the cap would be mapped to an EPT.

[1] https://github.com/seL4/rust-sel4/pull/305

