### PR TITLE
crates/sel4-sys: parse_xml on contents, not file

### DIFF
--- a/crates/sel4/sys/build/xml/mod.rs
+++ b/crates/sel4/sys/build/xml/mod.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 //
 
-use std::fs::File;
+use std::fs;
 use std::path::Path;
 
 use xmltree::Element;
@@ -17,5 +17,6 @@ mod condition;
 use condition::Condition;
 
 fn parse_xml(path: impl AsRef<Path>) -> Element {
-    Element::parse(File::open(path).unwrap()).unwrap()
+    let contents = fs::read(path).unwrap();
+    Element::parse(&*contents).unwrap()
 }


### PR DESCRIPTION
Turns out the XML parser, given a file handle, will read the XML byte-by-byte. When building with Cargo timings, we saw that about 0.5s is attributed to the build step of sel4-sys. When running the build script with strace we saw there was a read system call for each byte of the XML file. With this small change the build script now takes about 0.2s.