### PR TITLE
Make sel4 "state" feature opt-out-able across workspace

### DIFF
--- a/crates/examples/microkit/http-server/pds/server/Cargo.toml
+++ b/crates/examples/microkit/http-server/pds/server/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.28"
 microkit-http-server-example-server-core = { path = "core", features = [] }
 one-shot-mutex = "0.2.1"
 rtcc = "0.4.0"
-sel4 = { path = "../../../../../sel4" }
+sel4 = { path = "../../../../../sel4", default-features = false }
 sel4-abstract-allocator = { path = "../../../../../experimental/sel4-abstract-allocator" }
 sel4-async-block-io = { path = "../../../../../experimental/sel4-async/block-io" }
 sel4-async-block-io-fat = { path = "../../../../../experimental/sel4-async/block-io/fat" }

--- a/crates/examples/microkit/http-server/pds/virtio-blk-driver/Cargo.toml
+++ b/crates/examples/microkit/http-server/pds/virtio-blk-driver/Cargo.toml
@@ -18,7 +18,7 @@ license = "BSD-2-Clause"
 
 [dependencies]
 log = "0.4.28"
-sel4 = { path = "../../../../../sel4" }
+sel4 = { path = "../../../../../sel4", default-features = false }
 sel4-abstract-allocator = { path = "../../../../../experimental/sel4-abstract-allocator" }
 sel4-driver-interfaces = { path = "../../../../../experimental/sel4-driver-interfaces" }
 sel4-immediate-sync-once-cell = { path = "../../../../../sel4-immediate-sync-once-cell" }

--- a/crates/examples/microkit/http-server/pds/virtio-net-driver/Cargo.toml
+++ b/crates/examples/microkit/http-server/pds/virtio-net-driver/Cargo.toml
@@ -18,7 +18,7 @@ license = "BSD-2-Clause"
 
 [dependencies]
 log = "0.4.28"
-sel4 = { path = "../../../../../sel4" }
+sel4 = { path = "../../../../../sel4", default-features = false }
 sel4-abstract-allocator = { path = "../../../../../experimental/sel4-abstract-allocator" }
 sel4-immediate-sync-once-cell = { path = "../../../../../sel4-immediate-sync-once-cell" }
 sel4-logging = { path = "../../../../../sel4-logging" }

--- a/crates/examples/root-task/example-root-task/Cargo.toml
+++ b/crates/examples/root-task/example-root-task/Cargo.toml
@@ -17,5 +17,5 @@ edition = "2024"
 license = "BSD-2-Clause"
 
 [dependencies]
-sel4 = { path = "../../../sel4" }
+sel4 = { path = "../../../sel4", default-features = false }
 sel4-root-task = { path = "../../../sel4-root-task" }

--- a/crates/examples/root-task/hello/Cargo.toml
+++ b/crates/examples/root-task/hello/Cargo.toml
@@ -17,5 +17,5 @@ edition = "2024"
 license = "BSD-2-Clause"
 
 [dependencies]
-sel4 = { path = "../../../sel4" }
+sel4 = { path = "../../../sel4", default-features = false }
 sel4-root-task = { path = "../../../sel4-root-task" }

--- a/crates/examples/root-task/serial-device/Cargo.toml
+++ b/crates/examples/root-task/serial-device/Cargo.toml
@@ -17,6 +17,6 @@ edition = "2024"
 license = "BSD-2-Clause"
 
 [dependencies]
-sel4 = { path = "../../../sel4" }
+sel4 = { path = "../../../sel4", default-features = false }
 sel4-root-task = { path = "../../../sel4-root-task" }
 tock-registers = "0.10.0"

--- a/crates/examples/root-task/spawn-task/Cargo.toml
+++ b/crates/examples/root-task/spawn-task/Cargo.toml
@@ -18,5 +18,5 @@ license = "BSD-2-Clause"
 
 [dependencies]
 object = { version = "0.38.1", default-features = false, features = ["read"] }
-sel4 = { path = "../../../sel4" }
+sel4 = { path = "../../../sel4", default-features = false }
 sel4-root-task = { path = "../../../sel4-root-task" }

--- a/crates/examples/root-task/spawn-task/child/Cargo.toml
+++ b/crates/examples/root-task/spawn-task/child/Cargo.toml
@@ -19,7 +19,7 @@ license = "BSD-2-Clause"
 [dependencies]
 cfg-if = "1.0.4"
 one-shot-mutex = "0.2.1"
-sel4 = { path = "../../../../sel4" }
+sel4 = { path = "../../../../sel4", default-features = false, features = ["state"] }
 sel4-dlmalloc = { path = "../../../../sel4-dlmalloc" }
 sel4-panicking-env = { path = "../../../../sel4-panicking/env" }
 sel4-runtime-common = { path = "../../../../sel4-runtime-common", features = ["sel4"] }

--- a/crates/examples/root-task/spawn-thread/Cargo.toml
+++ b/crates/examples/root-task/spawn-thread/Cargo.toml
@@ -18,7 +18,7 @@ license = "BSD-2-Clause"
 
 [dependencies]
 cfg-if = "1.0.4"
-sel4 = { path = "../../../sel4" }
+sel4 = { path = "../../../sel4", default-features = false, features = ["state"] }
 sel4-elf-header = { path = "../../../sel4-elf-header" }
 sel4-initialize-tls = { path = "../../../sel4-initialize-tls", features = ["on-heap"] }
 sel4-root-task = { path = "../../../sel4-root-task" }

--- a/crates/private/meta/Cargo.toml
+++ b/crates/private/meta/Cargo.toml
@@ -23,7 +23,7 @@ sel4-root-task = ["dep:sel4-root-task"]
 [dependencies]
 cfg-if = "1.0.4"
 log = "0.4.28"
-sel4 = { path = "../../sel4" }
+sel4 = { path = "../../sel4", default-features = false }
 sel4-abstract-allocator = { path = "../../experimental/sel4-abstract-allocator" }
 sel4-abstract-ptr = { path = "../../sel4-abstract-ptr" }
 sel4-abstract-rc = { path = "../../experimental/sel4-abstract-rc" }
@@ -76,7 +76,7 @@ path = "../../experimental/sel4-shared-ring-buffer/bookkeeping"
 sel4-platform-info = { path = "../../sel4-platform-info", optional = true }
 
 [target."cfg(not(target_thread_local))".dependencies]
-sel4 = { path = "../../sel4", features = ["single-threaded"] }
+sel4 = { path = "../../sel4", default-features = false, features = ["single-threaded"] }
 
 [target."cfg(target_arch = \"aarch64\")".dependencies]
 sel4-reset = { path = "../../experimental/sel4-reset" }

--- a/crates/private/support/sel4-root-task-default-test-harness/Cargo.toml
+++ b/crates/private/support/sel4-root-task-default-test-harness/Cargo.toml
@@ -17,6 +17,6 @@ edition = "2024"
 license = "BSD-2-Clause"
 
 [dependencies]
-sel4 = { path = "../../../sel4" }
+sel4 = { path = "../../../sel4", default-features = false }
 sel4-root-task = { path = "../../../sel4-root-task" }
 sel4-test-harness = { path = "../sel4-test-harness" }

--- a/crates/private/support/sel4-root-task-with-std/Cargo.toml
+++ b/crates/private/support/sel4-root-task-with-std/Cargo.toml
@@ -20,6 +20,6 @@ license = "BSD-2-Clause"
 single-threaded = ["sel4/single-threaded"]
 
 [dependencies]
-sel4 = { path = "../../../sel4" }
+sel4 = { path = "../../../sel4", default-features = false, features = ["state"] }
 sel4-panicking-env = { path = "../../../sel4-panicking/env" }
 sel4-runtime-common = { path = "../../../sel4-runtime-common", features = ["sel4"] }

--- a/crates/private/support/sel4-simple-task/config-types/Cargo.toml
+++ b/crates/private/support/sel4-simple-task/config-types/Cargo.toml
@@ -21,5 +21,5 @@ cfg-if = "1.0.4"
 serde = { version = "1.0.228", default-features = false, features = ["derive"] }
 
 [target."cfg(target_os = \"none\")".dependencies]
-sel4 = { path = "../../../../sel4" }
+sel4 = { path = "../../../../sel4", default-features = false }
 sel4-simple-task-threading = { path = "../threading" }

--- a/crates/private/support/sel4-simple-task/rpc/Cargo.toml
+++ b/crates/private/support/sel4-simple-task/rpc/Cargo.toml
@@ -18,8 +18,9 @@ license = "BSD-2-Clause"
 
 [features]
 postcard = ["dep:serde", "dep:postcard"]
+state = ["sel4/state"]
 
 [dependencies]
 postcard = { version = "1.1.3", default-features = false, optional = true }
-sel4 = { path = "../../../../sel4" }
+sel4 = { path = "../../../../sel4", default-features = false }
 serde = { version = "1.0.228", default-features = false, optional = true }

--- a/crates/private/support/sel4-simple-task/rpc/src/lib.rs
+++ b/crates/private/support/sel4-simple-task/rpc/src/lib.rs
@@ -6,5 +6,5 @@
 
 #![no_std]
 
-#[cfg(feature = "postcard")]
+#[cfg(all(feature = "postcard", feature = "state"))]
 pub mod easy;

--- a/crates/private/support/sel4-simple-task/runtime/Cargo.toml
+++ b/crates/private/support/sel4-simple-task/runtime/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = ["dep:serde_json"]
 
 [dependencies]
 postcard = { version = "1.1.3", default-features = false }
-sel4 = { path = "../../../../sel4" }
+sel4 = { path = "../../../../sel4", default-features = false, features = ["state"] }
 sel4-dlmalloc = { path = "../../../../sel4-dlmalloc" }
 sel4-immediate-sync-once-cell = { path = "../../../../sel4-immediate-sync-once-cell" }
 sel4-panicking-env = { path = "../../../../sel4-panicking/env" }

--- a/crates/private/support/sel4-simple-task/threading/Cargo.toml
+++ b/crates/private/support/sel4-simple-task/threading/Cargo.toml
@@ -20,5 +20,5 @@ license = "MIT"
 alloc = []
 
 [dependencies]
-sel4 = { path = "../../../../sel4" }
+sel4 = { path = "../../../../sel4", default-features = false }
 sel4-panicking = { path = "../../../../sel4-panicking" }

--- a/crates/private/tests/capdl/threads/components/test/Cargo.toml
+++ b/crates/private/tests/capdl/threads/components/test/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 license = "BSD-2-Clause"
 
 [dependencies]
-sel4 = { path = "../../../../../../sel4" }
+sel4 = { path = "../../../../../../sel4", default-features = false }
 sel4-simple-task-config-types = { path = "../../../../../support/sel4-simple-task/config-types" }
 sel4-simple-task-runtime = { path = "../../../../../support/sel4-simple-task/runtime" }
 sel4-sync = { path = "../../../../../../sel4-sync" }

--- a/crates/private/tests/capdl/utcover/components/test/Cargo.toml
+++ b/crates/private/tests/capdl/utcover/components/test/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 license = "BSD-2-Clause"
 
 [dependencies]
-sel4 = { path = "../../../../../../sel4" }
+sel4 = { path = "../../../../../../sel4", default-features = false }
 sel4-simple-task-config-types = { path = "../../../../../support/sel4-simple-task/config-types" }
 sel4-simple-task-runtime = { path = "../../../../../support/sel4-simple-task/runtime" }
 serde = { version = "1.0.228", default-features = false, features = ["alloc", "derive"] }

--- a/crates/private/tests/root-task/alloca/Cargo.toml
+++ b/crates/private/tests/root-task/alloca/Cargo.toml
@@ -17,6 +17,6 @@ edition = "2024"
 license = "BSD-2-Clause"
 
 [dependencies]
-sel4 = { path = "../../../../sel4" }
+sel4 = { path = "../../../../sel4", default-features = false }
 sel4-alloca = { path = "../../../../sel4-alloca" }
 sel4-root-task = { path = "../../../../sel4-root-task" }

--- a/crates/private/tests/root-task/backtrace/Cargo.toml
+++ b/crates/private/tests/root-task/backtrace/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 license = "BSD-2-Clause"
 
 [dependencies]
-sel4 = { path = "../../../../sel4" }
+sel4 = { path = "../../../../sel4", default-features = false }
 sel4-backtrace = { path = "../../../../experimental/sel4-backtrace", features = ["full"] }
 sel4-root-task = { path = "../../../../sel4-root-task", features = ["alloc"] }
 

--- a/crates/private/tests/root-task/c/Cargo.toml
+++ b/crates/private/tests/root-task/c/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2024"
 license = "BSD-2-Clause"
 
 [dependencies]
-sel4 = { path = "../../../../sel4" }
+sel4 = { path = "../../../../sel4", default-features = false }
 sel4-root-task = { path = "../../../../sel4-root-task" }
 
 [dependencies.sel4-newlib]

--- a/crates/private/tests/root-task/config/Cargo.toml
+++ b/crates/private/tests/root-task/config/Cargo.toml
@@ -17,5 +17,5 @@ edition = "2024"
 license = "BSD-2-Clause"
 
 [dependencies]
-sel4 = { path = "../../../../sel4" }
+sel4 = { path = "../../../../sel4", default-features = false }
 sel4-root-task = { path = "../../../../sel4-root-task" }

--- a/crates/private/tests/root-task/dafny/task/Cargo.toml
+++ b/crates/private/tests/root-task/dafny/task/Cargo.toml
@@ -17,6 +17,6 @@ edition = "2024"
 license = "BSD-2-Clause"
 
 [dependencies]
-sel4 = { path = "../../../../../sel4" }
+sel4 = { path = "../../../../../sel4", default-features = false }
 sel4-root-task = { path = "../../../../../sel4-root-task" }
 tests-root-task-dafny-core = { path = "../core" }

--- a/crates/private/tests/root-task/loader/Cargo.toml
+++ b/crates/private/tests/root-task/loader/Cargo.toml
@@ -18,6 +18,6 @@ license = "BSD-2-Clause"
 
 [dependencies]
 fdt = "0.1.5"
-sel4 = { path = "../../../../sel4" }
+sel4 = { path = "../../../../sel4", default-features = false }
 sel4-platform-info = { path = "../../../../sel4-platform-info" }
 sel4-root-task = { path = "../../../../sel4-root-task" }

--- a/crates/private/tests/root-task/musl/Cargo.toml
+++ b/crates/private/tests/root-task/musl/Cargo.toml
@@ -19,7 +19,7 @@ license = "BSD-2-Clause"
 [dependencies]
 dlmalloc = "0.2.11"
 one-shot-mutex = "0.2.1"
-sel4 = { path = "../../../../sel4" }
+sel4 = { path = "../../../../sel4", default-features = false }
 sel4-dlmalloc = { path = "../../../../sel4-dlmalloc" }
 sel4-linux-syscall-types = { path = "../../../../experimental/sel4-linux-syscall-types" }
 sel4-musl = { path = "../../../../experimental/sel4-musl" }

--- a/crates/private/tests/root-task/panicking/Cargo.toml
+++ b/crates/private/tests/root-task/panicking/Cargo.toml
@@ -23,5 +23,5 @@ panic-unwind = []
 
 [dependencies]
 cfg-if = "1.0.4"
-sel4 = { path = "../../../../sel4" }
+sel4 = { path = "../../../../sel4", default-features = false }
 sel4-root-task = { path = "../../../../sel4-root-task" }

--- a/crates/private/tests/root-task/ring-test-harness/Cargo.toml
+++ b/crates/private/tests/root-task/ring-test-harness/Cargo.toml
@@ -19,7 +19,7 @@ license = "BSD-2-Clause"
 [dependencies]
 getrandom = { version = "0.2.10", features = ["custom"] }
 rand = { version = "0.10.0", default-features = false }
-sel4 = { path = "../../../../sel4" }
+sel4 = { path = "../../../../sel4", default-features = false }
 sel4-root-task = { path = "../../../../sel4-root-task" }
 sel4-test-harness = { path = "../../../support/sel4-test-harness" }
 

--- a/crates/private/tests/root-task/tls/Cargo.toml
+++ b/crates/private/tests/root-task/tls/Cargo.toml
@@ -17,5 +17,5 @@ edition = "2024"
 license = "BSD-2-Clause"
 
 [dependencies]
-sel4 = { path = "../../../../sel4" }
+sel4 = { path = "../../../../sel4", default-features = false }
 sel4-root-task = { path = "../../../../sel4-root-task" }

--- a/crates/private/tests/root-task/verus/task/Cargo.toml
+++ b/crates/private/tests/root-task/verus/task/Cargo.toml
@@ -17,6 +17,6 @@ edition = "2024"
 license = "BSD-2-Clause"
 
 [dependencies]
-sel4 = { path = "../../../../../sel4" }
+sel4 = { path = "../../../../../sel4", default-features = false }
 sel4-root-task = { path = "../../../../../sel4-root-task" }
 tests-root-task-verus-core = { path = "../core" }

--- a/crates/sel4-capdl-initializer/Cargo.toml
+++ b/crates/sel4-capdl-initializer/Cargo.toml
@@ -24,7 +24,7 @@ deflate = ["sel4-capdl-initializer-types/deflate"]
 [dependencies]
 log = "0.4.28"
 rkyv = { version = "0.8.12", default-features = false }
-sel4 = { path = "../sel4" }
+sel4 = { path = "../sel4", default-features = false }
 sel4-capdl-initializer-types = { path = "types", features = ["sel4"] }
 sel4-immediate-sync-once-cell = { path = "../sel4-immediate-sync-once-cell" }
 sel4-immutable-cell = { path = "../sel4-immutable-cell" }

--- a/crates/sel4-microkit/Cargo.toml
+++ b/crates/sel4-microkit/Cargo.toml
@@ -23,7 +23,7 @@ full = ["alloc"]
 [dependencies]
 cfg-if = "1.0.4"
 one-shot-mutex = "0.2.1"
-sel4 = { path = "../sel4", features = ["single-threaded"] }
+sel4 = { path = "../sel4", default-features = false, features = ["single-threaded", "state"] }
 sel4-dlmalloc = { path = "../sel4-dlmalloc" }
 sel4-immediate-sync-once-cell = { path = "../sel4-immediate-sync-once-cell" }
 sel4-microkit-base = { path = "base" }

--- a/crates/sel4-microkit/base/Cargo.toml
+++ b/crates/sel4-microkit/base/Cargo.toml
@@ -20,5 +20,5 @@ license = "BSD-2-Clause"
 extern-symbols = []
 
 [dependencies]
-sel4 = { path = "../../sel4" }
+sel4 = { path = "../../sel4", default-features = false, features = ["state"] }
 sel4-immutable-cell = { path = "../../sel4-immutable-cell" }

--- a/crates/sel4-root-task/Cargo.toml
+++ b/crates/sel4-root-task/Cargo.toml
@@ -22,7 +22,7 @@ full = ["alloc"]
 single-threaded = ["sel4/single-threaded"]
 
 [dependencies]
-sel4 = { path = "../sel4" }
+sel4 = { path = "../sel4", default-features = false, features = ["state"] }
 sel4-dlmalloc = { path = "../sel4-dlmalloc" }
 sel4-immediate-sync-once-cell = { path = "../sel4-immediate-sync-once-cell" }
 sel4-panicking = { path = "../sel4-panicking", features = ["personality", "panic-handler"] }

--- a/crates/sel4-sync/Cargo.toml
+++ b/crates/sel4-sync/Cargo.toml
@@ -18,5 +18,5 @@ license = "MIT"
 
 [dependencies]
 lock_api = "0.4.14"
-sel4 = { path = "../sel4" }
+sel4 = { path = "../sel4", default-features = false }
 sel4-immediate-sync-once-cell = { path = "../sel4-immediate-sync-once-cell" }


### PR DESCRIPTION
Add `default-features = false` to all in-workspace `sel4` dependencies so the `state` feature (thread-local IPC buffer) is not forced on every crate by feature unification.

Runtime crates that require state (`sel4-root-task`, `sel4-microkit`, `sel4-microkit-base`, `sel4-simple-task-runtime`, `sel4-root-task-with-std`, `spawn-task-child`, `spawn-thread`) explicitly request `features = ["state"]` on their `sel4` dependency. All other crates get only `default-features = false`.

Validated by: `make run-fast-tests` (all tests pass on all architectures)