### PR TITLE
Add 32-bit MCS support

### DIFF
--- a/crates/examples/root-task/spawn-task/src/main.rs
+++ b/crates/examples/root-task/spawn-task/src/main.rs
@@ -61,16 +61,30 @@ fn main(bootinfo: &sel4::BootInfoPtr) -> sel4::Result<Never> {
 
     let child_tcb = object_allocator.allocate_fixed_sized::<sel4::cap_type::Tcb>();
 
-    child_tcb
-        .tcb_configure(
-            sel4::init_thread::slot::NULL.cptr(),
-            child_cnode,
-            sel4::CNodeCapData::new(0, sel4::WORD_SIZE - child_cnode_size_bits),
-            child_vspace,
-            ipc_buffer_addr as sel4::Word,
-            ipc_buffer_cap,
-        )
-        .unwrap();
+    sel4::sel4_cfg_if! {
+        if #[sel4_cfg(KERNEL_MCS)] {
+            child_tcb
+                .tcb_configure(
+                    child_cnode,
+                    sel4::CNodeCapData::new(0, sel4::WORD_SIZE - child_cnode_size_bits),
+                    child_vspace,
+                    ipc_buffer_addr as sel4::Word,
+                    ipc_buffer_cap,
+                )
+                .unwrap();
+        } else {
+            child_tcb
+                .tcb_configure(
+                    sel4::init_thread::slot::NULL.cptr(),
+                    child_cnode,
+                    sel4::CNodeCapData::new(0, sel4::WORD_SIZE - child_cnode_size_bits),
+                    child_vspace,
+                    ipc_buffer_addr as sel4::Word,
+                    ipc_buffer_cap,
+                )
+                .unwrap();
+        }
+    }
 
     child_cnode
         .absolute_cptr_from_bits_with_depth(2, child_cnode_size_bits)

--- a/crates/examples/root-task/spawn-thread/src/main.rs
+++ b/crates/examples/root-task/spawn-thread/src/main.rs
@@ -44,14 +44,26 @@ fn main(bootinfo: &sel4::BootInfoPtr) -> sel4::Result<Never> {
 
     let secondary_thread_tcb = object_allocator.allocate_fixed_sized::<sel4::cap_type::Tcb>();
 
-    secondary_thread_tcb.tcb_configure(
-        sel4::init_thread::slot::NULL.cptr(),
-        sel4::init_thread::slot::CNODE.cap(),
-        sel4::CNodeCapData::new(0, 0),
-        sel4::init_thread::slot::VSPACE.cap(),
-        SECONDARY_THREAD_IPC_BUFFER_FRAME.ptr() as sel4::Word,
-        SECONDARY_THREAD_IPC_BUFFER_FRAME.cap(bootinfo),
-    )?;
+    sel4::sel4_cfg_if! {
+        if #[sel4_cfg(KERNEL_MCS)] {
+            secondary_thread_tcb.tcb_configure(
+                sel4::init_thread::slot::CNODE.cap(),
+                sel4::CNodeCapData::new(0, 0),
+                sel4::init_thread::slot::VSPACE.cap(),
+                SECONDARY_THREAD_IPC_BUFFER_FRAME.ptr() as sel4::Word,
+                SECONDARY_THREAD_IPC_BUFFER_FRAME.cap(bootinfo),
+            )?;
+        } else {
+            secondary_thread_tcb.tcb_configure(
+                sel4::init_thread::slot::NULL.cptr(),
+                sel4::init_thread::slot::CNODE.cap(),
+                sel4::CNodeCapData::new(0, 0),
+                sel4::init_thread::slot::VSPACE.cap(),
+                SECONDARY_THREAD_IPC_BUFFER_FRAME.ptr() as sel4::Word,
+                SECONDARY_THREAD_IPC_BUFFER_FRAME.cap(bootinfo),
+            )?;
+        }
+    }
 
     let secondary_thread_fn = SecondaryThreadFn::new(move || {
         unsafe { sel4::set_ipc_buffer(SECONDARY_THREAD_IPC_BUFFER_FRAME.ptr().as_mut().unwrap()) }

--- a/crates/sel4/sys/src/fault/mod.rs
+++ b/crates/sel4/sys/src/fault/mod.rs
@@ -47,11 +47,23 @@ impl seL4_Fault {
                 #[sel4_cfg(KERNEL_MCS)]
                 seL4_Fault_tag::seL4_Fault_Timeout => {
                     assert!(length == seL4_Timeout_Msg::seL4_Timeout_Length.into());
-                    seL4_Fault_Timeout_Unpacked {
-                        data: f(seL4_Timeout_Msg::seL4_Timeout_Data.into()),
-                        consumed: f(seL4_Timeout_Msg::seL4_Timeout_Consumed.into()),
+                    #[cfg(target_pointer_width = "64")]
+                    {
+                        seL4_Fault_Timeout_Unpacked {
+                            data: f(seL4_Timeout_Msg::seL4_Timeout_Data.into()),
+                            consumed: f(seL4_Timeout_Msg::seL4_Timeout_Consumed.into()),
+                        }
+                        .unsplay()
                     }
-                    .unsplay()
+                    #[cfg(target_pointer_width = "32")]
+                    {
+                        seL4_Fault_Timeout_Unpacked {
+                            data: f(seL4_Timeout_Msg::seL4_Timeout_Data.into()),
+                            consumed_high: f(seL4_Timeout_Msg::seL4_Timeout_Consumed_HighBits.into()),
+                            consumed_low: f(seL4_Timeout_Msg::seL4_Timeout_Consumed_LowBits.into()),
+                        }
+                        .unsplay()
+                    }
                 }
                 _ => {
                     match Self::arch_get_with(label, length, f) {

--- a/hacking/nix/scope/world/instances/default.nix
+++ b/hacking/nix/scope/world/instances/default.nix
@@ -43,6 +43,7 @@ let
   haveUnwindingSupport = !stdenv.hostPlatform.isAarch32;
   haveKernelLoader = stdenv.hostPlatform.isAarch || stdenv.hostPlatform.isRiscV;
   haveCapDLInitializer = true;
+  isMCS = seL4Config.KERNEL_MCS or false;
 
   maybe = condition: v: if condition then v else null;
 
@@ -467,7 +468,7 @@ in rec {
             '';
       }));
 
-      spawn-thread = maybe haveFullRuntime (mkInstance {
+      spawn-thread = maybe (haveFullRuntime && !isMCS) (mkInstance {
         rootTask = mkTask {
           rootCrate = crates.spawn-thread;
           release = false;
@@ -477,7 +478,7 @@ in rec {
         };
       });
 
-      spawn-task = maybe haveFullRuntime (
+      spawn-task = maybe (haveFullRuntime && !isMCS) (
         let
           child = mkTask {
             rootCrate = crates.spawn-task-child;

--- a/hacking/nix/top-level/aggregates.nix
+++ b/hacking/nix/top-level/aggregates.nix
@@ -16,9 +16,11 @@ in {
     pkgs.host.aarch64.none.this.worlds.default
     pkgs.host.aarch64.none.this.worlds.qemu-arm-virt.microkit
     pkgs.host.aarch32.none.this.worlds.default
+    pkgs.host.aarch32.none.this.worlds.qemu-arm-virt.mcs
     pkgs.host.riscv64.default.none.this.worlds.default
     pkgs.host.riscv64.default.none.this.worlds.qemu-riscv-virt.microkit
     pkgs.host.riscv32.default.none.this.worlds.default
+    pkgs.host.riscv32.default.none.this.worlds.spike.mcs
     pkgs.host.x86_64.none.this.worlds.default
     pkgs.host.x86_64.none.this.worlds.pc99.microkit
   ];


### PR DESCRIPTION
Add aarch32/riscv32 MCS worlds. Fix timeout fault consumed field (split high/low on 32-bit) and `tcb_configure` calls. Exclude spawn examples from MCS.

Verified by: `make run-fast-tests`