### PR TITLE
Bump `rustls-webpki`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,9 +2102,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
Addresses:

https://rustsec.org/advisories/RUSTSEC-2026-0098
https://rustsec.org/advisories/RUSTSEC-2026-0099