### PR TITLE
capdl: Fix untyped alignment issue

### DIFF
--- a/crates/sel4-capdl-initializer/src/initialize.rs
+++ b/crates/sel4-capdl-initializer/src/initialize.rs
@@ -17,7 +17,7 @@ use rkyv::option::ArchivedOption;
 use log::{debug, error, info, trace};
 
 use sel4::{
-    CapRights, CapTypeForFrameObjectOfFixedSize, cap_type,
+    CapRights, CapTypeForFrameObjectOfFixedSize, WORD_SIZE, cap_type,
     init_thread::{self, Slot},
 };
 use sel4_capdl_initializer_types::*;
@@ -249,9 +249,13 @@ impl<'a> Initializer<'a> {
                 };
                 let target_is_obj_with_paddr = target < ut_paddr_end;
                 while cur_paddr < target {
-                    let max_size_bits = usize::try_from(cur_paddr.trailing_zeros())
-                        .unwrap()
-                        .min((target - cur_paddr).trailing_zeros().try_into().unwrap());
+                    let max_size_bits = {
+                        let alignment_bits = (cur_paddr - ut_paddr_start)
+                            .checked_ilog2()
+                            .unwrap_or(WORD_SIZE.try_into().unwrap());
+                        let distance_bits = (target - cur_paddr).checked_ilog2().expect("never 0");
+                        alignment_bits.min(distance_bits).try_into().unwrap()
+                    };
                     let mut created = false;
                     if !ut.is_device() {
                         for size_bits in (0..=max_size_bits).rev() {


### PR DESCRIPTION
As noted in #319, on some platforms such as x86_64, it is not safe to assume that an untyped object's alignment, from the perspective of the kernel, is equal to the alignment of its physical address.

Before this patch, the CapDL initializer made this invalid assumption, resulting in incorrect untyped object watermark bookkeeping.

This patch switches to computing the alignment of the untyped object at a given physical address by considering the alignment of the offset between that physical address and the physical address of the parent untyped object. This is sound because we know that the parent untyped object is aligned to its own size.