### PR TITLE
crates/sel4: support non HUGE_PAGE kernel build

### DIFF
--- a/crates/sel4/src/arch/x86/arch/x64/object.rs
+++ b/crates/sel4/src/arch/x86/arch/x64/object.rs
@@ -17,6 +17,7 @@ pub type ObjectBlueprintSeL4Arch = ObjectBlueprintX64;
 #[sel4_cfg_enum]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ObjectTypeX64 {
+    #[sel4_cfg(HUGE_PAGE)]
     HugePage,
     PDPT,
     PML4,
@@ -30,6 +31,7 @@ impl ObjectTypeX64 {
     pub(crate) const fn into_sys(self) -> c_uint {
         sel4_cfg_wrap_match! {
             match self {
+                #[sel4_cfg(HUGE_PAGE)]
                 Self::HugePage => sys::_mode_object::seL4_X64_HugePageObject,
                 Self::PDPT => sys::_mode_object::seL4_X86_PDPTObject,
                 Self::PML4 => sys::_mode_object::seL4_X64_PML4Object,
@@ -45,6 +47,7 @@ impl ObjectTypeX64 {
 #[sel4_cfg_enum]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ObjectBlueprintX64 {
+    #[sel4_cfg(HUGE_PAGE)]
     HugePage,
     PDPT,
     PML4,
@@ -58,6 +61,7 @@ impl ObjectBlueprintX64 {
     pub(crate) const fn ty(self) -> ObjectTypeX64 {
         sel4_cfg_wrap_match! {
             match self {
+                #[sel4_cfg(HUGE_PAGE)]
                 Self::HugePage => ObjectTypeX64::HugePage,
                 Self::PDPT => ObjectTypeX64::PDPT,
                 Self::PML4 => ObjectTypeX64::PML4,
@@ -72,6 +76,7 @@ impl ObjectBlueprintX64 {
     pub(crate) const fn physical_size_bits(self) -> usize {
         sel4_cfg_wrap_match! {
             match self {
+                #[sel4_cfg(HUGE_PAGE)]
                 Self::HugePage => u32_into_usize(sys::seL4_HugePageBits),
                 Self::PDPT => u32_into_usize(sys::seL4_PDPTBits),
                 Self::PML4 => u32_into_usize(sys::seL4_PML4Bits),

--- a/crates/sel4/src/arch/x86/mod.rs
+++ b/crates/sel4/src/arch/x86/mod.rs
@@ -68,10 +68,15 @@ pub(crate) mod cap_type_arch {
         ObjectTypeArch,
         ObjectBlueprintArch
     });
-    declare_cap_type_for_object_of_fixed_size!(HugePage {
-        ObjectTypeSeL4Arch,
-        ObjectBlueprintSeL4Arch
-    });
+
+    sel4_cfg_if! {
+        if #[sel4_cfg(HUGE_PAGE)] {
+            declare_cap_type_for_object_of_fixed_size!(HugePage {
+                ObjectTypeSeL4Arch,
+                ObjectBlueprintSeL4Arch
+            });
+        }
+    }
 
     declare_cap_type_for_object_of_fixed_size!(PML4 {
         ObjectTypeSeL4Arch,
@@ -111,7 +116,12 @@ pub(crate) mod cap_arch {
 
     declare_cap_alias!(_4k);
     declare_cap_alias!(LargePage);
-    declare_cap_alias!(HugePage);
+
+    sel4_cfg_if! {
+        if #[sel4_cfg(HUGE_PAGE)] {
+            declare_cap_alias!(HugePage);
+        }
+    }
 
     declare_cap_alias!(PML4);
     declare_cap_alias!(PDPT);

--- a/crates/sel4/src/arch/x86/vspace.rs
+++ b/crates/sel4/src/arch/x86/vspace.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-use sel4_config::{sel4_cfg, sel4_cfg_enum, sel4_cfg_wrap_match};
+use sel4_config::{sel4_cfg, sel4_cfg_enum, sel4_cfg_if, sel4_cfg_wrap_match};
 
 use crate::{
     CapTypeForFrameObject, CapTypeForFrameObjectOfFixedSize, CapTypeForTranslationTableObject,
@@ -13,10 +13,12 @@ use crate::{
 };
 
 /// Frame object types for this kernel configuration.
+#[sel4_cfg_enum]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum FrameObjectType {
     _4k,
     LargePage,
+    #[sel4_cfg(HUGE_PAGE)]
     HugePage,
 }
 
@@ -24,27 +26,35 @@ impl FrameObjectType {
     pub const GRANULE: Self = Self::_4k;
 
     pub const fn blueprint(self) -> ObjectBlueprint {
-        match self {
-            Self::_4k => ObjectBlueprint::Arch(ObjectBlueprintX86::_4k),
-            Self::LargePage => ObjectBlueprint::Arch(ObjectBlueprintX86::LargePage),
-            Self::HugePage => {
-                ObjectBlueprint::Arch(ObjectBlueprintX86::SeL4Arch(ObjectBlueprintX64::HugePage))
+        sel4_cfg_wrap_match! {
+            match self {
+                Self::_4k => ObjectBlueprint::Arch(ObjectBlueprintX86::_4k),
+                Self::LargePage => ObjectBlueprint::Arch(ObjectBlueprintX86::LargePage),
+                #[sel4_cfg(HUGE_PAGE)]
+                Self::HugePage => {
+                    ObjectBlueprint::Arch(ObjectBlueprintX86::SeL4Arch(ObjectBlueprintX64::HugePage))
+                }
             }
         }
     }
 
     pub const fn from_bits(bits: usize) -> Option<Self> {
-        Some(match bits {
-            Self::_4K_BITS => Self::_4k,
-            Self::LARGE_PAGE_BITS => Self::LargePage,
-            Self::HUGE_PAGE_BITS => Self::HugePage,
-            _ => return None,
+        Some(sel4_cfg_wrap_match! {
+            match bits {
+                Self::_4K_BITS => Self::_4k,
+                Self::LARGE_PAGE_BITS => Self::LargePage,
+                #[sel4_cfg(HUGE_PAGE)]
+                Self::HUGE_PAGE_BITS => Self::HugePage,
+                _ => return None,
+            }
         })
     }
 
     // For match arm LHS's, as we can't call const fn's
     pub const _4K_BITS: usize = Self::_4k.bits();
     pub const LARGE_PAGE_BITS: usize = Self::LargePage.bits();
+
+    #[sel4_cfg(HUGE_PAGE)]
     pub const HUGE_PAGE_BITS: usize = Self::HugePage.bits();
 }
 
@@ -60,10 +70,14 @@ impl CapTypeForFrameObjectOfFixedSize for cap_type::LargePage {
     const FRAME_OBJECT_TYPE: FrameObjectType = FrameObjectType::LargePage;
 }
 
-impl CapTypeForFrameObject for cap_type::HugePage {}
+sel4_cfg_if! {
+    if #[sel4_cfg(HUGE_PAGE)] {
+        impl CapTypeForFrameObject for cap_type::HugePage {}
 
-impl CapTypeForFrameObjectOfFixedSize for cap_type::HugePage {
-    const FRAME_OBJECT_TYPE: FrameObjectType = FrameObjectType::HugePage;
+        impl CapTypeForFrameObjectOfFixedSize for cap_type::HugePage {
+            const FRAME_OBJECT_TYPE: FrameObjectType = FrameObjectType::HugePage;
+        }
+    }
 }
 
 // // //


### PR DESCRIPTION
Previously the code assumes that the kernel always have 1GB huge page enabled on x86. But this may not be the case since some x86 environment such as cloud VM or older machines won't support it.

I've updated the code so that it works with huge page disabled in the kernel.