### PR TITLE
sel4-capdl-initializer: lazy SC rebind for passive

### DIFF
--- a/crates/sel4-capdl-initializer/src/initialize.rs
+++ b/crates/sel4-capdl-initializer/src/initialize.rs
@@ -833,6 +833,20 @@ impl<'a> Initializer<'a> {
                         )?;
 
                         tcb.tcb_set_timeout_endpoint(temp_fault_ep)?;
+
+                        if obj.extra.passive {
+                            if let Some(bound_sc) = obj.sc() {
+                                if let Some(bound_ntfn) = obj.bound_notification() {
+                                    let bound_ntfn_cap =
+                                        self.orig_cap::<cap_type::Notification>(bound_ntfn.object);
+                                    sc.bind_ntfn(bound_ntfn_cap)?;
+                                } else {
+                                    panic!("A passive task must have its own Notification.");
+                                }
+                            } else {
+                                panic!("A passive task must have its own Scheduling Context.");
+                            }
+                        }
                     } else {
                         let fault_ep = sel4::CPtr::from_bits(obj.extra.master_fault_ep.as_ref().unwrap().to_sel4());
 

--- a/crates/sel4-capdl-initializer/types/src/spec.rs
+++ b/crates/sel4-capdl-initializer/types/src/spec.rs
@@ -429,6 +429,8 @@ pub mod object {
         pub gprs: Vec<Word>,
 
         pub master_fault_ep: Option<Word>,
+
+        pub passive: bool,
     }
 
     #[derive(Debug, Clone, Eq, PartialEq, IsObject, HasCapTable)]

--- a/crates/sel4/src/invocations.rs
+++ b/crates/sel4/src/invocations.rs
@@ -348,6 +348,15 @@ impl<C: InvocationContext> SchedControl<C> {
 
 #[sel4_cfg(KERNEL_MCS)]
 impl<C: InvocationContext> SchedContext<C> {
+    /// Corresponds to `seL4_SchedContext_Bind`.
+    pub fn bind_ntfn(self, notification: Notification) -> Result<()> {
+        Error::wrap(self.invoke(|cptr, ipc_buffer| {
+            ipc_buffer
+                .inner_mut()
+                .seL4_SchedContext_Bind(cptr.bits(), notification.bits())
+        }))
+    }
+
     /// Corresponds to `seL4_SchedContext_Unbind`.
     pub fn unbind(self) -> Result<()> {
         Error::wrap(self.invoke(|cptr, ipc_buffer| {


### PR DESCRIPTION
Implements lazy Scheduling Context rebind for passive tasks inside the capDL initialiser.

Solves problems such as https://github.com/seL4/microkit/issues/91