### PR TITLE
Expose `"extern-symbols"` feature via `sel4-microkit`

### DIFF
--- a/crates/sel4-microkit/Cargo.nix
+++ b/crates/sel4-microkit/Cargo.nix
@@ -31,5 +31,8 @@ mk {
     alloc = [
       "sel4-panicking/alloc" "sel4-microkit-base/alloc"
     ];
+    extern-symbols = [
+      "sel4-microkit-base/extern-symbols"
+    ];
   };
 }

--- a/crates/sel4-microkit/Cargo.toml
+++ b/crates/sel4-microkit/Cargo.toml
@@ -18,6 +18,7 @@ license = "BSD-2-Clause"
 
 [features]
 alloc = ["sel4-panicking/alloc", "sel4-microkit-base/alloc"]
+extern-symbols = ["sel4-microkit-base/extern-symbols"]
 full = ["alloc"]
 
 [dependencies]


### PR DESCRIPTION
To make this feature of `sel4-microkit-base` more convenient to enable.