### PR TITLE
add bootinfo for x86

### DIFF
--- a/crates/sel4-capdl-initializer/types/src/frame_init.rs
+++ b/crates/sel4-capdl-initializer/types/src/frame_init.rs
@@ -94,6 +94,12 @@ pub struct FillEntryContentBootInfo {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(rkyv::Archive, rkyv::Serialize)]
 pub enum FillEntryContentBootInfoId {
+    Padding,
+    X86Vbe,
+    X86Mbmmap,
+    X86AcpiRsdp,
+    X86FrameBuffer,
+    X86TscFreq,
     Fdt,
 }
 

--- a/crates/sel4-capdl-initializer/types/src/when_sel4.rs
+++ b/crates/sel4-capdl-initializer/types/src/when_sel4.rs
@@ -123,6 +123,12 @@ impl ArchivedRights {
 impl ArchivedFillEntryContentBootInfoId {
     pub fn to_sel4(&self) -> sel4::BootInfoExtraId {
         match self {
+            Self::Padding => sel4::BootInfoExtraId::Padding,
+            Self::X86Vbe => sel4::BootInfoExtraId::X86Vbe,
+            Self::X86Mbmmap => sel4::BootInfoExtraId::X86Mbmmap,
+            Self::X86AcpiRsdp => sel4::BootInfoExtraId::X86AcpiRsdp,
+            Self::X86FrameBuffer => sel4::BootInfoExtraId::X86FrameBuffer,
+            Self::X86TscFreq => sel4::BootInfoExtraId::X86TscFreq,
             Self::Fdt => sel4::BootInfoExtraId::Fdt,
         }
     }

--- a/crates/sel4/src/bootinfo.rs
+++ b/crates/sel4/src/bootinfo.rs
@@ -167,6 +167,11 @@ impl BootInfoExtra<'_> {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BootInfoExtraId {
     Padding,
+    X86Vbe,
+    X86Mbmmap,
+    X86AcpiRsdp,
+    X86FrameBuffer,
+    X86TscFreq,
     Fdt,
 }
 
@@ -174,6 +179,19 @@ impl BootInfoExtraId {
     pub fn from_sys(id: sys::seL4_BootInfoID::Type) -> Option<Self> {
         match id {
             sys::seL4_BootInfoID::SEL4_BOOTINFO_HEADER_PADDING => Some(BootInfoExtraId::Padding),
+            sys::seL4_BootInfoID::SEL4_BOOTINFO_HEADER_X86_VBE => Some(BootInfoExtraId::X86Vbe),
+            sys::seL4_BootInfoID::SEL4_BOOTINFO_HEADER_X86_MBMMAP => {
+                Some(BootInfoExtraId::X86Mbmmap)
+            }
+            sys::seL4_BootInfoID::SEL4_BOOTINFO_HEADER_X86_ACPI_RSDP => {
+                Some(BootInfoExtraId::X86AcpiRsdp)
+            }
+            sys::seL4_BootInfoID::SEL4_BOOTINFO_HEADER_X86_FRAMEBUFFER => {
+                Some(BootInfoExtraId::X86FrameBuffer)
+            }
+            sys::seL4_BootInfoID::SEL4_BOOTINFO_HEADER_X86_TSC_FREQ => {
+                Some(BootInfoExtraId::X86TscFreq)
+            }
             sys::seL4_BootInfoID::SEL4_BOOTINFO_HEADER_FDT => Some(BootInfoExtraId::Fdt),
             _ => None,
         }


### PR DESCRIPTION
This PR adds BootInfoIDs for x86, which is required by [`bootinfo` tag support in Microkit](https://github.com/au-ts/microkit/tree/add-bootinfo-tag). It is useful for the use cases where the userland needs to access some of boot information, e.g., [Microkit #525](https://github.com/seL4/microkit/issues/525). 

The `BootInfoExtra` iteration found `padding` tag and tried to [read out of boundary](https://github.com/seL4/rust-sel4/blob/c30d0e44fb32c15239049ce402ef2a8c72499aa3/crates/sel4/src/bootinfo.rs#L220-L221) due to wrong `extraLen`, which is fixed by [this kernel PR](https://github.com/seL4/seL4/pull/1696).