### PR TITLE
capdl: Fix untyped alignment issue, again

### DIFF
--- a/crates/sel4-capdl-initializer/src/initialize.rs
+++ b/crates/sel4-capdl-initializer/src/initialize.rs
@@ -17,7 +17,7 @@ use rkyv::option::ArchivedOption;
 use log::{debug, error, info, trace};
 
 use sel4::{
-    CapRights, CapTypeForFrameObjectOfFixedSize, WORD_SIZE, cap_type,
+    CapRights, CapTypeForFrameObjectOfFixedSize, cap_type,
     init_thread::{self, Slot},
 };
 use sel4_capdl_initializer_types::*;
@@ -250,9 +250,7 @@ impl<'a> Initializer<'a> {
                 let target_is_obj_with_paddr = target < ut_paddr_end;
                 while cur_paddr < target {
                     let max_size_bits = {
-                        let alignment_bits = (cur_paddr - ut_paddr_start)
-                            .checked_ilog2()
-                            .unwrap_or(WORD_SIZE.try_into().unwrap());
+                        let alignment_bits = (cur_paddr - ut_paddr_start).trailing_zeros();
                         let distance_bits = (target - cur_paddr).checked_ilog2().expect("never 0");
                         alignment_bits.min(distance_bits).try_into().unwrap()
                     };


### PR DESCRIPTION
#350 introduced a bug. Alignment should be computed using `trailing_zeros()`, not `ilog2()`.