### PR TITLE
IOMMU: Add IOMMU Support

### DIFF
--- a/crates/sel4-capdl-initializer/src/initialize.rs
+++ b/crates/sel4-capdl-initializer/src/initialize.rs
@@ -89,6 +89,11 @@ impl<'a> Initializer<'a> {
         self.init_asids()?;
         self.init_frames()?;
         self.init_vspaces()?;
+        sel4::sel4_cfg_if! {
+            if #[sel4_cfg(all(ARCH_X86_64,IOMMU))] {
+                self.init_iospaces()?;
+            }
+        }
 
         sel4::sel4_cfg_if! {
             if #[sel4_cfg(KERNEL_MCS)] {
@@ -686,6 +691,139 @@ impl<'a> Initializer<'a> {
             }
         }
         Ok(())
+    }
+
+    #[sel4::sel4_cfg(all(ARCH_X86_64, IOMMU))]
+    fn init_iospaces(&mut self) -> Result<()> {
+        debug!("Initialising IOSpaces");
+        // Early exit if no IOSpace Objects exist
+        if !self
+            .filter_objects::<object::ArchivedIOSpace>()
+            .any(|_| true)
+        {
+            return Ok(());
+        }
+
+        let num_iopt_levels = self.bootinfo.inner().numIOPTLevels as usize;
+        if num_iopt_levels < x86_io_address_space::CAPDL_NUM_IOPT_LEVELS {
+            panic!(
+                "Error: we have assumed at least a 39 bit (3-level) address space would be supported."
+            )
+        }
+        if num_iopt_levels > x86_io_address_space::MAX_RUNTIME_NUM_LEVELS {
+            panic!("Error: seL4 reported an unsupported x86 IOPT depth.")
+        }
+
+        // We assume that the IO Address Space was created to support 39 bit addresses (seL4 calls this 3 level)
+        // Prefix depth is the number extra levels that seL4 requires, based off its runtime decision
+        let prefix_depth = num_iopt_levels - x86_io_address_space::CAPDL_NUM_IOPT_LEVELS;
+
+        for (obj_id, obj) in self.filter_objects::<object::ArchivedIOSpace>() {
+            let iospace = self.mint_iospace_cap(obj_id, obj)?;
+
+            let root_iopt_obj_id = self.init_iospace_prefix(iospace, obj, prefix_depth)?;
+
+            let root_iopt = self.object_as::<object::ArchivedIOPageTable>(root_iopt_obj_id);
+            self.init_iospace(iospace, 0, root_iopt)?;
+        }
+
+        Ok(())
+    }
+
+    #[sel4::sel4_cfg(all(ARCH_X86_64, IOMMU))]
+    fn mint_iospace_cap(
+        &self,
+        obj_id: ArchivedObjectId,
+        obj: &object::ArchivedIOSpace,
+    ) -> Result<sel4::cap::IOSpace> {
+        let dst_slot = self.orig_cslot(obj_id);
+        let dst = cslot_to_absolute_cptr(dst_slot);
+        let src = cslot_to_absolute_cptr(init_thread::slot::IO_SPACE.upcast());
+
+        // Two inherent limitations are present if using CapDL statically:
+        // The first is it assumes that a user knows the PCI BDF information ahead of time, not true
+        // since this is runtime information. The second is the spec assumes that all domain ids are
+        // valid, which is also not true since the kernel may reserve an unknown number of domain
+        // ids during boot.
+        let (pci_bus, pci_dev, pci_fn) = obj.pci_device.to_sel4();
+
+        let cap_data =
+            sel4::io_space::IOSpaceCapData::new(obj.domain_id.to_sel4(), pci_bus, pci_dev, pci_fn);
+
+        dst.mint(&src, CapRights::all(), cap_data.into())
+            .map(|_| Ok(self.orig_cap::<cap_type::IOSpace>(obj_id)))
+            .unwrap_or_else(|err| panic!("Error: {err} when minting an x86 IOSpace capability."))
+    }
+
+    #[sel4::sel4_cfg(all(ARCH_X86_64, IOMMU))]
+    fn init_iospace_prefix(
+        &self,
+        iospace: sel4::cap::IOSpace,
+        obj: &object::ArchivedIOSpace,
+        prefix_depth: usize,
+    ) -> Result<ArchivedObjectId> {
+        for slot in (0..=prefix_depth).rev() {
+            let iopt = Self::get_iopt_obj_id(obj, slot);
+            self.orig_cap::<cap_type::IOPageTable>(iopt)
+                .io_page_table_map(iospace, 0)?;
+        }
+
+        // Return obj id of the root page table
+        Ok(Self::get_iopt_obj_id(obj, 0))
+    }
+
+    #[sel4::sel4_cfg(all(ARCH_X86_64, IOMMU))]
+    fn init_iospace(
+        &mut self,
+        iospace: sel4::cap::IOSpace,
+        ioaddr: usize,
+        obj: &object::ArchivedIOPageTable,
+    ) -> Result<()> {
+        let iopt_level = obj.level.to_sel4() as usize;
+        if iopt_level >= x86_io_address_space::CAPDL_NUM_IOPT_LEVELS {
+            panic!(
+                "Error: the capdl spec contains an extra level of page tables, violating our assumed {} level format!",
+                x86_io_address_space::CAPDL_NUM_IOPT_LEVELS
+            );
+        }
+        for (i, entry) in obj.entries() {
+            let ioaddr = ioaddr
+                + (usize::from(i)
+                    << sel4::io_space::levels::step_bits(
+                        x86_io_address_space::CAPDL_NUM_IOPT_LEVELS,
+                        iopt_level,
+                    ));
+
+            match entry {
+                IOPageTableEntry::IOPageTable(cap) => {
+                    self.orig_cap::<cap_type::IOPageTable>(cap.object)
+                        .io_page_table_map(iospace, ioaddr.try_into().unwrap())?;
+
+                    let iopt_object = self.object_as::<object::ArchivedIOPageTable>(cap.object);
+                    self.init_iospace(iospace, ioaddr, iopt_object)?;
+                }
+                IOPageTableEntry::Frame(cap) => {
+                    let frame = self.orig_cap::<cap_type::UnspecifiedPage>(cap.object);
+                    let rights = cap.rights.to_sel4();
+
+                    self.copy(frame)?
+                        .io_frame_map(iospace, rights, ioaddr.try_into().unwrap())?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    #[sel4::sel4_cfg(all(ARCH_X86_64, IOMMU))]
+    fn get_iopt_obj_id(obj: &object::ArchivedIOSpace, slot: usize) -> ArchivedObjectId {
+        obj.slots
+            .iter()
+            .find(|entry| usize::from(entry.slot) == slot)
+            .map(|entry| match &entry.cap {
+                ArchivedCap::IOPageTable(cap) => cap.object,
+                _ => panic!("unexpected non-IOPageTable cap in IOSpace slot"),
+            })
+            .unwrap_or_else(|| panic!("missing IOPageTable in IOSpace slot {slot}"))
     }
 
     #[sel4::sel4_cfg(KERNEL_MCS)]

--- a/crates/sel4-capdl-initializer/types/src/lib.rs
+++ b/crates/sel4-capdl-initializer/types/src/lib.rs
@@ -15,6 +15,7 @@ use rkyv::util::AlignedVec;
 mod cap_table;
 mod frame_init;
 mod spec;
+pub mod x86_io_address_space;
 
 #[cfg(feature = "transform")]
 mod transform;

--- a/crates/sel4-capdl-initializer/types/src/spec.rs
+++ b/crates/sel4-capdl-initializer/types/src/spec.rs
@@ -191,6 +191,8 @@ pub enum Object<D> {
     Frame(object::Frame<D>),
     PageTable(object::PageTable),
     AsidPool(object::AsidPool),
+    IOSpace(object::IOSpace),
+    IOPageTable(object::IOPageTable),
     ArmIrq(object::ArmIrq),
     IrqMsi(object::IrqMsi),
     IrqIOApic(object::IrqIOApic),
@@ -225,6 +227,8 @@ impl<D> Object<D> {
             Self::CNode(obj) => obj.slots(),
             Self::Tcb(obj) => obj.slots(),
             Self::PageTable(obj) => obj.slots(),
+            Self::IOSpace(obj) => obj.slots(),
+            Self::IOPageTable(obj) => obj.slots(),
             Self::ArmIrq(obj) => obj.slots(),
             Self::IrqMsi(obj) => obj.slots(),
             Self::IrqIOApic(obj) => obj.slots(),
@@ -238,6 +242,8 @@ impl<D> Object<D> {
             Self::CNode(obj) => &mut obj.slots,
             Self::Tcb(obj) => &mut obj.slots,
             Self::PageTable(obj) => &mut obj.slots,
+            Self::IOSpace(obj) => &mut obj.slots,
+            Self::IOPageTable(obj) => &mut obj.slots,
             Self::ArmIrq(obj) => &mut obj.slots,
             Self::IrqMsi(obj) => &mut obj.slots,
             Self::IrqIOApic(obj) => &mut obj.slots,
@@ -279,6 +285,8 @@ pub enum Cap {
     Frame(cap::Frame),
     PageTable(cap::PageTable),
     AsidPool(cap::AsidPool),
+    IOSpace(cap::IOSpace),
+    IOPageTable(cap::IOPageTable),
     ArmIrqHandler(cap::ArmIrqHandler),
     IrqMsiHandler(cap::IrqMsiHandler),
     IrqIOApicHandler(cap::IrqIOApicHandler),
@@ -312,6 +320,8 @@ impl Cap {
             Self::VCpu(cap) => cap.object,
             Self::PageTable(cap) => cap.object,
             Self::AsidPool(cap) => cap.object,
+            Self::IOSpace(cap) => cap.object,
+            Self::IOPageTable(cap) => cap.object,
             Self::ArmIrqHandler(cap) => cap.object,
             Self::IrqMsiHandler(cap) => cap.object,
             Self::IrqIOApicHandler(cap) => cap.object,
@@ -336,6 +346,8 @@ impl Cap {
             Self::VCpu(cap) => cap.object = object,
             Self::PageTable(cap) => cap.object = object,
             Self::AsidPool(cap) => cap.object = object,
+            Self::IOSpace(cap) => cap.object = object,
+            Self::IOPageTable(cap) => cap.object = object,
             Self::ArmIrqHandler(cap) => cap.object = object,
             Self::IrqMsiHandler(cap) => cap.object = object,
             Self::IrqIOApicHandler(cap) => cap.object = object,
@@ -370,6 +382,8 @@ impl ArchivedCap {
             Self::VCpu(cap) => cap.object,
             Self::PageTable(cap) => cap.object,
             Self::AsidPool(cap) => cap.object,
+            Self::IOSpace(cap) => cap.object,
+            Self::IOPageTable(cap) => cap.object,
             Self::ArmIrqHandler(cap) => cap.object,
             Self::IrqMsiHandler(cap) => cap.object,
             Self::IrqIOApicHandler(cap) => cap.object,
@@ -463,6 +477,39 @@ pub mod object {
     #[derive(rkyv::Archive, rkyv::Serialize)]
     pub struct AsidPool {
         pub high: Word,
+    }
+
+    #[derive(Debug, Clone, Eq, PartialEq, IsObject, HasCapTable)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[derive(rkyv::Archive, rkyv::Serialize)]
+    pub struct IOSpace {
+        pub slots: Vec<CapTableEntry>,
+        pub domain_id: Word,
+        pub pci_device: PCIDevice,
+    }
+
+    #[derive(Debug, Clone, Copy, Eq, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[derive(rkyv::Archive, rkyv::Serialize)]
+    pub struct PCIDevice {
+        pub bus: u8,
+        pub device: u8,
+        pub function: u8,
+    }
+
+    impl PCIDevice {
+        #![allow(dead_code)]
+        pub const PCI_BUS_MAX: u8 = u8::MAX;
+        pub const PCI_DEV_MAX: u8 = (1 << 5) - 1;
+        pub const PCI_FUNC_MAX: u8 = (1 << 3) - 1;
+    }
+
+    #[derive(Debug, Clone, Eq, PartialEq, IsObject, HasCapTable)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[derive(rkyv::Archive, rkyv::Serialize)]
+    pub struct IOPageTable {
+        pub slots: Vec<CapTableEntry>,
+        pub level: Word,
     }
 
     #[derive(Debug, Clone, Eq, PartialEq, IsObject, HasCapTable)]
@@ -659,6 +706,20 @@ pub mod cap {
     #[derive(Debug, Clone, Eq, PartialEq, IsCap)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     #[derive(rkyv::Archive, rkyv::Serialize)]
+    pub struct IOSpace {
+        pub object: ObjectId,
+    }
+
+    #[derive(Debug, Clone, Eq, PartialEq, IsCap)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[derive(rkyv::Archive, rkyv::Serialize)]
+    pub struct IOPageTable {
+        pub object: ObjectId,
+    }
+
+    #[derive(Debug, Clone, Eq, PartialEq, IsCap)]
+    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+    #[derive(rkyv::Archive, rkyv::Serialize)]
     pub struct ArmIrqHandler {
         pub object: ObjectId,
     }
@@ -733,6 +794,26 @@ impl object::ArchivedPageTable {
                 match &entry.cap {
                     ArchivedCap::PageTable(cap) => PageTableEntry::PageTable(cap),
                     ArchivedCap::Frame(cap) => PageTableEntry::Frame(cap),
+                    _ => panic!(),
+                },
+            )
+        })
+    }
+}
+
+pub enum IOPageTableEntry<'a> {
+    IOPageTable(&'a cap::ArchivedIOPageTable),
+    Frame(&'a cap::ArchivedFrame),
+}
+
+impl object::ArchivedIOPageTable {
+    pub fn entries(&self) -> impl Iterator<Item = (ArchivedCapSlot, IOPageTableEntry<'_>)> {
+        self.slots.iter().map(|entry| {
+            (
+                entry.slot,
+                match &entry.cap {
+                    ArchivedCap::IOPageTable(cap) => IOPageTableEntry::IOPageTable(cap),
+                    ArchivedCap::Frame(cap) => IOPageTableEntry::Frame(cap),
                     _ => panic!(),
                 },
             )

--- a/crates/sel4-capdl-initializer/types/src/transform.rs
+++ b/crates/sel4-capdl-initializer/types/src/transform.rs
@@ -103,6 +103,8 @@ impl<D> Spec<D> {
                             }),
                             Object::PageTable(obj) => Object::PageTable(obj.clone()),
                             Object::AsidPool(obj) => Object::AsidPool(obj.clone()),
+                            Object::IOSpace(obj) => Object::IOSpace(obj.clone()),
+                            Object::IOPageTable(obj) => Object::IOPageTable(obj.clone()),
                             Object::ArmIrq(obj) => Object::ArmIrq(obj.clone()),
                             Object::IrqMsi(obj) => Object::IrqMsi(obj.clone()),
                             Object::IrqIOApic(obj) => Object::IrqIOApic(obj.clone()),

--- a/crates/sel4-capdl-initializer/types/src/when_sel4.rs
+++ b/crates/sel4-capdl-initializer/types/src/when_sel4.rs
@@ -10,7 +10,7 @@ use sel4::{ObjectBlueprint, VmAttributes};
 
 use crate::{
     ArchivedCap, ArchivedFillEntryContentBootInfoId, ArchivedObject, ArchivedRights, ArchivedWord,
-    cap,
+    cap, object::ArchivedPCIDevice,
 };
 
 impl<D: Archive> ArchivedObject<D> {
@@ -68,6 +68,8 @@ impl<D: Archive> ArchivedObject<D> {
                     assert_eq!(obj.is_root, level == 0); // sanity check
                     sel4::TranslationTableObjectType::from_level(level.into()).unwrap().blueprint()
                 }
+                #[sel4_cfg(all(ARCH_X86_64, IOMMU))]
+                ArchivedObject::IOPageTable(_) => sel4::ObjectBlueprintArch::IOPageTable.into(),
                 ArchivedObject::AsidPool(_) => ObjectBlueprint::asid_pool(),
                 #[sel4_cfg(KERNEL_MCS)]
                 ArchivedObject::SchedContext(obj) => ObjectBlueprint::SchedContext {
@@ -111,6 +113,12 @@ impl ArchivedWord {
     #[allow(clippy::useless_conversion)]
     pub fn to_sel4(&self) -> sel4::Word {
         self.0.to_native().try_into().unwrap()
+    }
+}
+
+impl ArchivedPCIDevice {
+    pub fn to_sel4(&self) -> (sel4::Word, sel4::Word, sel4::Word) {
+        (self.bus.into(), self.device.into(), self.function.into())
     }
 }
 

--- a/crates/sel4-capdl-initializer/types/src/x86_io_address_space.rs
+++ b/crates/sel4-capdl-initializer/types/src/x86_io_address_space.rs
@@ -1,0 +1,30 @@
+//
+// Copyright 2026, UNSW
+//
+// SPDX-License-Identifier: BSD-2-Clause
+//
+
+/* seL4 does not enforce a fixed io address space layout. In particular the maximum virtual address
+ width is determined at run-time and reported in the bootinfo. In addition, support for different
+ page sizes i.e. 4KiB and 2MiB is also only determined at runtime. Finally, the set of valid
+ domain IDs required when minting an IOSpace capability is only determined at runtime.
+ Thus to enable generation of a CAPDL spec we make simplifying assumptions defined in here.
+*/
+
+/// The number of x86 VT-d IOPT levels represented directly in the capDL spec.
+/// seL4 may report a wider runtime IOVA space in bootinfo. In that case the
+/// initializer maps zero-address prefix IOPTs above this lower 39-bit tree.
+pub const CAPDL_NUM_IOPT_LEVELS: usize = 3;
+
+/// For clients to build a consistent spec we define the maximum IOVA that
+/// can be supported, independent of what seL4 reports at run time.
+pub const CAPDL_MAX_IOVA: u64 = (1_u64 << 39) - 1;
+
+/// The maximum x86 VT-d IOPT depth seL4 can report for a 64-bit IOVA space.
+pub const MAX_RUNTIME_NUM_LEVELS: usize = 6;
+
+/// Number of spare IOPTs the capDL spec reserves for runtime prefix levels.
+pub const SPARE_NUM_LEVELS: usize = MAX_RUNTIME_NUM_LEVELS - CAPDL_NUM_IOPT_LEVELS;
+
+/// The reserved slot on the IOSpace object that holds the root IOPT.
+pub const IOSPACE_ROOT_IOPT_SLOT: usize = 0;

--- a/crates/sel4/src/arch/x86/invocations.rs
+++ b/crates/sel4/src/arch/x86/invocations.rs
@@ -63,6 +63,18 @@ impl<T: CapTypeForFrameObject, C: InvocationContext> Cap<T, C> {
         }))
     }
 
+    #[sel4_cfg(IOMMU)]
+    pub fn io_frame_map(self, iospace: IOSpace, rights: CapRights, ioaddr: Word) -> Result<()> {
+        Error::wrap(self.invoke(|cptr, ipc_buffer| {
+            ipc_buffer.inner_mut().seL4_X86_Page_MapIO(
+                cptr.bits(),
+                iospace.bits(),
+                rights.into_inner(),
+                ioaddr,
+            )
+        }))
+    }
+
     /// Corresponds to `seL4_X86_Page_Unmap`.
     pub fn frame_unmap(self) -> Result<()> {
         Error::wrap(
@@ -174,6 +186,25 @@ impl<C: InvocationContext> EPTPageTable<C> {
                 vaddr.try_into().unwrap(),
                 attr.into_inner(),
             )
+        }))
+    }
+}
+
+#[sel4_cfg(IOMMU)]
+impl<C: InvocationContext> IOPageTable<C> {
+    pub fn io_page_table_map(self, iospace: IOSpace, ioaddr: Word) -> Result<()> {
+        Error::wrap(self.invoke(|cptr, ipc_buffer| {
+            ipc_buffer
+                .inner_mut()
+                .seL4_X86_IOPageTable_Map(cptr.bits(), iospace.bits(), ioaddr)
+        }))
+    }
+
+    pub fn io_page_table_unmap(self) -> Result<()> {
+        Error::wrap(self.invoke(|cptr, ipc_buffer| {
+            ipc_buffer
+                .inner_mut()
+                .seL4_X86_IOPageTable_Unmap(cptr.bits())
         }))
     }
 }

--- a/crates/sel4/src/arch/x86/mod.rs
+++ b/crates/sel4/src/arch/x86/mod.rs
@@ -22,6 +22,9 @@ pub(crate) mod top_level {
         vm_attributes::VmAttributes,
         vspace::{FrameObjectType, TranslationTableObjectType},
     };
+
+    #[crate::sel4_cfg(all(ARCH_X86_64, IOMMU))]
+    pub use super::vspace::io_space;
 }
 
 pub(crate) use vspace::vspace_levels;
@@ -57,6 +60,16 @@ pub(crate) mod cap_type_arch {
                 /// Corresponds to `seL4_X86_EPTPT`.
                 EPTPageTable { ObjectTypeArch, ObjectBlueprintArch }
             );
+        }
+    }
+
+    sel4_cfg_if! {
+        if #[sel4_cfg(IOMMU)] {
+            declare_cap_type_for_object_of_fixed_size!(
+                IOPageTable { ObjectTypeArch, ObjectBlueprintArch }
+            );
+
+            declare_cap_type!(IOSpace);
         }
     }
 
@@ -111,6 +124,13 @@ pub(crate) mod cap_arch {
             declare_cap_alias!(EPTPDPT);
             declare_cap_alias!(EPTPageDirectory);
             declare_cap_alias!(EPTPageTable);
+        }
+    }
+
+    sel4_cfg_if! {
+        if #[sel4_cfg(IOMMU)] {
+            declare_cap_alias!(IOPageTable);
+            declare_cap_alias!(IOSpace);
         }
     }
 

--- a/crates/sel4/src/arch/x86/object.rs
+++ b/crates/sel4/src/arch/x86/object.rs
@@ -24,6 +24,8 @@ pub enum ObjectTypeX86 {
     LargePage,
     PageTable,
     PageDirectory,
+    #[sel4_cfg(IOMMU)]
+    IOPageTable,
     #[sel4_cfg(VTX)]
     VCpu,
     #[sel4_cfg(VTX)]
@@ -41,6 +43,8 @@ impl ObjectTypeX86 {
                 Self::LargePage => sys::_object::seL4_X86_LargePageObject,
                 Self::PageTable => sys::_object::seL4_X86_PageTableObject,
                 Self::PageDirectory => sys::_object::seL4_X86_PageDirectoryObject,
+                #[sel4_cfg(IOMMU)]
+                Self::IOPageTable => sys::_object::seL4_X86_IOPageTableObject,
                 #[sel4_cfg(VTX)]
                 Self::VCpu => sys::_object::seL4_X86_VCPUObject,
                 #[sel4_cfg(VTX)]
@@ -72,6 +76,8 @@ pub enum ObjectBlueprintX86 {
     LargePage,
     PageTable,
     PageDirectory,
+    #[sel4_cfg(IOMMU)]
+    IOPageTable,
     #[sel4_cfg(VTX)]
     VCpu,
     #[sel4_cfg(VTX)]
@@ -89,6 +95,8 @@ impl ObjectBlueprintX86 {
                 Self::LargePage => ObjectTypeX86::LargePage,
                 Self::PageTable => ObjectTypeX86::PageTable,
                 Self::PageDirectory => ObjectTypeX86::PageDirectory,
+                #[sel4_cfg(IOMMU)]
+                Self::IOPageTable => ObjectTypeX86::IOPageTable,
                 #[sel4_cfg(VTX)]
                 Self::VCpu => ObjectTypeX86::VCpu,
                 #[sel4_cfg(VTX)]
@@ -107,6 +115,8 @@ impl ObjectBlueprintX86 {
                 Self::LargePage => u32_into_usize(sys::seL4_LargePageBits),
                 Self::PageTable => u32_into_usize(sys::seL4_PageTableBits),
                 Self::PageDirectory => u32_into_usize(sys::seL4_PageDirBits),
+                #[sel4_cfg(IOMMU)]
+                Self::IOPageTable => u32_into_usize(sys::seL4_IOPageTableBits),
                 #[sel4_cfg(VTX)]
                 Self::VCpu => u32_into_usize(sys::seL4_VCPUBits),
                 #[sel4_cfg(VTX)]

--- a/crates/sel4/src/arch/x86/vspace.rs
+++ b/crates/sel4/src/arch/x86/vspace.rs
@@ -98,6 +98,8 @@ pub enum TranslationTableObjectType {
     EPTPageDirectory,
     #[sel4_cfg(VTX)]
     EPTPageTable,
+    #[sel4_cfg(IOMMU)]
+    IOPageTable,
 }
 
 impl TranslationTableObjectType {
@@ -124,6 +126,8 @@ impl TranslationTableObjectType {
                 Self::EPTPageDirectory => ObjectBlueprint::Arch(ObjectBlueprintX86::EPTPageDirectory),
                 #[sel4_cfg(VTX)]
                 Self::EPTPageTable => ObjectBlueprint::Arch(ObjectBlueprintX86::EPTPageTable),
+                #[sel4_cfg(IOMMU)]
+                Self::IOPageTable => ObjectBlueprint::Arch(ObjectBlueprintX86::IOPageTable),
             }
         }
     }
@@ -143,6 +147,8 @@ impl TranslationTableObjectType {
                 Self::EPTPageDirectory => u32_into_usize(sys::seL4_X86_EPTPDIndexBits),
                 #[sel4_cfg(VTX)]
                 Self::EPTPageTable => u32_into_usize(sys::seL4_X86_EPTPTIndexBits),
+                #[sel4_cfg(IOMMU)]
+                Self::IOPageTable => u32_into_usize(sys::seL4_IOPageTableIndexBits),
             }
         }
     }
@@ -167,6 +173,11 @@ impl TranslationTableObjectType {
             _ => return None,
         })
     }
+
+    #[sel4_cfg(IOMMU)]
+    pub const fn from_level_io_page_table(_level: usize) -> Option<Self> {
+        Some(Self::IOPageTable)
+    }
 }
 
 impl CapTypeForTranslationTableObject for cap_type::PML4 {
@@ -189,8 +200,70 @@ impl CapTypeForTranslationTableObject for cap_type::PageTable {
         TranslationTableObjectType::PageTable;
 }
 
+#[sel4_cfg(IOMMU)]
+impl CapTypeForTranslationTableObject for cap_type::IOPageTable {
+    const TRANSLATION_TABLE_OBJECT_TYPE: TranslationTableObjectType =
+        TranslationTableObjectType::IOPageTable;
+}
+
 pub mod vspace_levels {
     pub const NUM_LEVELS: usize = 4;
 
     pub const HIGHEST_LEVEL_WITH_PAGE_ENTRIES: usize = NUM_LEVELS - 3;
+}
+
+#[sel4_cfg(all(ARCH_X86_64, IOMMU))]
+pub mod io_space {
+    use super::sys;
+    use crate::{Word, newtype_methods};
+
+    use sel4_sys::seL4_X86_IOSpace_CapData;
+    /// Corresponds to `seL4_IOSpace_CapData`.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct IOSpaceCapData(sys::seL4_X86_IOSpace_CapData);
+
+    impl IOSpaceCapData {
+        newtype_methods!(pub sys::seL4_X86_IOSpace_CapData);
+
+        pub fn new(domain_id: u64, pci_bus: u64, pci_dev: u64, pci_fun: u64) -> Self {
+            Self::from_inner(seL4_X86_IOSpace_CapData::new(
+                domain_id, pci_bus, pci_dev, pci_fun,
+            ))
+        }
+
+        pub fn into_word(self) -> Word {
+            let [word] = self.into_inner().0.into_inner();
+            word
+        }
+    }
+
+    impl From<IOSpaceCapData> for Word {
+        fn from(cap_data: IOSpaceCapData) -> Self {
+            cap_data.into_word()
+        }
+    }
+
+    pub mod levels {
+        use super::super::{FrameObjectType, TranslationTableObjectType};
+
+        // On x86 the leaf entries are normal frame objects, not IOMMU specific
+        fn span_bits(num_levels: usize, level: usize) -> usize {
+            assert!(level < num_levels);
+            (level..num_levels)
+                .map(|level| {
+                    TranslationTableObjectType::from_level_io_page_table(level)
+                        .unwrap()
+                        .index_bits()
+                })
+                .sum::<usize>()
+                + FrameObjectType::GRANULE.bits()
+        }
+
+        pub fn step_bits(num_levels: usize, level: usize) -> usize {
+            span_bits(num_levels, level)
+                - TranslationTableObjectType::from_level_io_page_table(level)
+                    .unwrap()
+                    .index_bits()
+        }
+    }
 }

--- a/crates/sel4/src/init_thread.rs
+++ b/crates/sel4/src/init_thread.rs
@@ -142,8 +142,8 @@ pub mod slot {
         (IO_PORT_CONTROL, Null, seL4_CapIOPortControl),
         #[sel4_cfg(ARCH_X86_64)]
         (IO_PORT_CONTROL, IOPortControl, seL4_CapIOPortControl),
-        #[cfg(false)] // TODO
-        (IO_SPACE, Null, seL4_CapIOSpace),
+        #[sel4_cfg(all(ARCH_X86_64, IOMMU))]
+        (IO_SPACE, IOSpace, seL4_CapIOSpace),
         (BOOT_INFO_FRAME, Granule, seL4_CapBootInfoFrame),
         (IPC_BUFFER, Granule, seL4_CapInitThreadIPCBuffer),
         (DOMAIN_SET, DomainSet, seL4_CapDomain),


### PR DESCRIPTION
This commit adds support for the creation of IOMMU address spaces on x86.

The capdl spec for defining an IO Address Space on x86 is a root IODevice object, which contains in slot 0 the root IOPageTable object and in slots 1.. spare IOPageTable objects. These IOPageTable objects are similar to the normal x86 page table structures.

At runtime, the initialiser will calculate how many of the spare page tables must be mapped.  It does this by taking the difference of what seL4 reports to be the number of page table levels and the configured number of levels we define in the x86_io_address_space module.

This means that capdl enforces a fixed upper limit on the maximum IO virtual address and will fail if seL4 reports that the IOMMU supports less than this maximum. If seL4 reports support for a larger maximum IO virtual address, this design works by mapping in the spare page tables into the highest levels of the hierarchy in slot 0, until we reach the page table responsible for translating the first valid bits of the maximum IO virtual address.